### PR TITLE
Issue 8: midje-mode is incompatible with clojure-test-mode

### DIFF
--- a/src/midje/util/report.clj
+++ b/src/midje/util/report.clj
@@ -1,11 +1,16 @@
+(when (= (class clojure.test/report) clojure.lang.MultiFn)
+  (eval
+   '(do (require 'clojure.test)
+        (ns clojure.test)
+        (defonce old-report clojure.test/report))))
+
 (ns midje.util.report
     (:use clojure.test))
 
 (defn- midje-position-string [position-pair]
   (format "(%s:%d)" (first position-pair) (second position-pair)))
 
-
-(defmethod clojure.test/report :mock-argument-match-failure [m]
+(defmethod clojure.test/old-report :mock-argument-match-failure [m]
 ;  (with-test-out
    (inc-report-counter :fail)
    (println "\nFAIL at" (midje-position-string (:position m)))
@@ -13,7 +18,7 @@
    (println "You never said" (:name (meta (:function m))) "would be called with these arguments:")
    (println (pr-str (:actual m))))
 
-(defmethod clojure.test/report :mock-incorrect-call-count [m]
+(defmethod clojure.test/old-report :mock-incorrect-call-count [m]
 ;  (with-test-out
    (inc-report-counter :fail)
    (println "\nFAIL for" (midje-position-string (:position m)))
@@ -22,7 +27,7 @@
    (println (:expected m) "should be called at least once."))
 
 
-(defmethod clojure.test/report :mock-expected-result-failure [m]
+(defmethod clojure.test/old-report :mock-expected-result-failure [m]
 ;  (with-test-out
    (inc-report-counter :fail)
    (println "\nFAIL at" (midje-position-string (:position m)))
@@ -30,7 +35,7 @@
    (println "expected:" (pr-str (:expected m)))
    (println "  actual:" (pr-str (:actual m))))
 
-(defmethod clojure.test/report :mock-expected-result-functional-failure [m]
+(defmethod clojure.test/old-report :mock-expected-result-functional-failure [m]
 ;  (with-test-out
    (inc-report-counter :fail)
    (println "\nFAIL at" (midje-position-string (:position m)))


### PR DESCRIPTION
Hi,

Reference: http://github.com/marick/Midje/issues#issue/8

I followed tcrayford's suggestion and it does fix the "clojure.test$report cannot be cast to clojure.lang.MultiFn" error (when using Midje and clojure-test-mode).

Another problem is that clojure-test-mode doesn't register Midje test failures, so this patch is not enough. But it does the minimum: it allows users to use Midje without removing clojure-test-mode, and let them customize clojure-test-mode to register Midje test failures.

The patch is ugly though, so please feel free to reject this request (and maybe find a cleaner solution).

Note: when running "lein test", the 91 tests pass.

Cheers!
