### PR TITLE
Report error when attempting prerequisite for private function

### DIFF
--- a/src/midje/error_handling/semi_sweet_validations.clj
+++ b/src/midje/error_handling/semi_sweet_validations.clj
@@ -27,8 +27,11 @@
 
         (exposed-testable? (first funcall))
         (validation-error-report-form
-         form
-         "Prerequisites cannot be specified for private functions exposed with expose-testables.")
+          form
+          "A prerequisite cannot be specified on a function exposed via expose-testables."
+          (cl-format nil "Instead, specify it directly on the var: #'~S/~S"
+                     (-> (first funcall) fnref-var-object meta :ns ns-name)
+                     (first funcall)))
 
         :else
         form))))


### PR DESCRIPTION
I took a stab at adding the error message discussed in Issue #140. Please let me know if there is a better way to approach this.

The test run now looks like:

```
% lein midje

FAIL at (foobar/test/core.clj:14)
    Midje could not understand something you wrote: 
        Prerequisites cannot be specified for private functions exposed with expose-testables.
FAILURE: 1 fact was not confirmed. (But 1 was.)
```

I'd be happy to add a corresponding test in test/midje/test/t_semi_sweet_validations.clj. Do you have any suggestions for where to put a private function for testing? Or should I test against an existing one?
