### PR TITLE
Removed `intern+keep-meta`

### DIFF
--- a/src/midje/sweet.clj
+++ b/src/midje/sweet.clj
@@ -40,16 +40,10 @@
        :dynamic true}
   *include-midje-checks* *include-midje-checks*)
 
-;; TODO: How is this different from defalias?
-(defn- intern+keep-meta [ns sym v]
-  (intern ns sym v)
-  (let [newguy (get (ns-interns ns) sym)]
-    (alter-meta! newguy merge (meta v))))
-
-(intern+keep-meta *ns* 'before  #'background/before)
-(intern+keep-meta *ns* 'after   #'background/after)
-(intern+keep-meta *ns* 'around  #'background/around)
-(intern+keep-meta *ns* 'formula #'parse-formulas/formula)
+(defalias before  background/before)
+(defalias after   background/after)
+(defalias around  background/around)
+(defalias formula parse-formulas/formula)
 
 (when (doc/appropriate?)
   (immigrate-from 'midje.doc doc/for-sweet)


### PR DESCRIPTION
We use `defalias` instead.

PS
Not exactly the hoped prerequisites-with-metadata feature (I guess it’s too complex for me), but hey, I should start somewhere, right? ;) HTH
- src/midje/sweet.clj:
