### PR TITLE
Extracted filter function from `separate-filters`

### DIFF
--- a/src/midje/parsing/other/arglists.clj
+++ b/src/midje/parsing/other/arglists.clj
@@ -38,24 +38,19 @@
   ( (if (describes-name-matcher? desired) name-matcher-for callable-matcher-for) 
     desired))
 
-(defn desired-fact-predicate-from [desireds]
-  (vary-meta
+(defn desired-fact-predicate-from [default-filter desireds]
+  (if (empty? desireds)
+    (appropriate-matcher-for default-filter)
+    (vary-meta
      (pile/any-pred-from (map appropriate-matcher-for desireds))
-     assoc :created-from desireds))
+     assoc :created-from desireds)))
 
-
-;;; TODO: Whatever happened to the single-responsibility principle? Should this
-;;; really both separate filters *and* compile them into a predicate?
-(defn separate-filters [args plain-argument? default-filter]
+(defn separate-filters [args plain-argument?]
   (let [[filters remainder]
-        (separate #(and (not (plain-argument? %)) 
+        (separate #(and (not (plain-argument? %))
                         ((pile/any-pred-from [string? regex? fn? keyword?]) %))
                   args)]
-    (vector filters
-            (if (empty? filters)
-              (appropriate-matcher-for default-filter)
-              (desired-fact-predicate-from filters))
-            remainder)))
+    (vector filters remainder)))
 
 
 ;;;                                           Keyword options with 0 or more arguments.

--- a/src/midje/repl.clj
+++ b/src/midje/repl.clj
@@ -107,8 +107,9 @@
                               (config/choice :fact-filter)))))
   (let [[given-level-seq print-level-to-use args]
           (parsing/separate-print-levels original-args (config/choice :print-level))
-        [filters filter-function namespaces]
-          (parsing/separate-filters args all-keyword-is-not-a-filter (config/choice :fact-filter))]
+        [filters namespaces]
+        (parsing/separate-filters args all-keyword-is-not-a-filter)
+        filter-function (parsing/desired-fact-predicate-from (config/choice :fact-filter) filters)]
 
     (if (empty? namespaces)
       (defaulting-args


### PR DESCRIPTION
I hope I correctly understood you TODO.
- src/midje/parsing/other/arglists.clj:
  - Moved filter function from `separate-filters` to
    `desired-fact-predicate-from`.
- src/midje/repl.clj:
  - Updated `let` bindings to use the new function.
- test/midje/parsing/other/t_arglists.clj:
  - Updated tests
