### PR TITLE
Adding travis support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+language: clojure
+lein: lein2
+script: lein2 midje

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@ Available via [clojars](http://clojars.org/search?q=midje)
 Current stable version: [midje "1.4.0"]        
 Development version: [midje "1.5-beta2"]  - see [ the change log](https://github.com/marick/Midje/wiki/What%27s-new-in-midje-1.5)
 
+[![Build Status](https://travis-ci.org/marick/Midje.png?branch=master)](https://travis-ci.org/marick/Midje)
+
 
 [User guide](https://github.com/marick/Midje/wiki)    
 [Tutorial](https://github.com/marick/Midje-quickstart/wiki)


### PR DESCRIPTION
Unless there is a explict reason you are not using Travis I thought it would be a useful addition as an opensource CI tool.

https://travis-ci.org/

I've added the pre-requisite files. 
You would need to create a travis account and connect Midje.

I also added the travis current build status to the readme (see as an example: https://github.com/josephwilk/stereotype-clj)
