### PR TITLE
Update to gui-diff 0.5.0

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -16,7 +16,7 @@
                  [org.clojure/tools.namespace "0.2.2"]
                  [slingshot "0.10.3"]
                  [commons-codec/commons-codec "1.6"]
-                 [gui-diff "0.3.9"]]
+                 [gui-diff "0.5.0"]]
   :profiles {:dev {:dependencies [[slamhound "1.2.0"]
                                   [jonase/kibit "0.0.3"]
                                   [jonase/eastwood "0.0.2"]]

--- a/src/midje/emission/plugins/util.clj
+++ b/src/midje/emission/plugins/util.clj
@@ -8,7 +8,7 @@
             [midje.emission.colorize :as color]
             [midje.util.exceptions :as exception]
             [midje.config :as config]
-            gui-diff.internal))
+            gui.diff))
 
 
 ;; The theory here was that using clojure.test output would allow text
@@ -27,7 +27,7 @@
 (defn indented [lines]
   (map (partial str "        ") lines))
 
-(def sorted-if-appropriate gui-diff.internal/nested-sort)
+(def sorted-if-appropriate gui.diff/nested-sort)
 
 (defn linearize-lines
   "Takes a nested structure that contains nils and strings.


### PR DESCRIPTION
The namespace structure of gui-diff changed between 0.3.9 (current) and 0.5.0 (latest).

This patch allows updates Midje to use 0.5.0 so it can be used alongside dependencies which require recent versions of gui-diff.
