### PR TITLE
Convey thread bindings (*out* specifically)

### DIFF
--- a/src/midje/util/scheduling.clj
+++ b/src/midje/util/scheduling.clj
@@ -14,6 +14,7 @@
   (when (@scheduled-futures service-tag)
     (stop service-tag))
   (let [executor (ScheduledThreadPoolExecutor. 1)
+        function (bound-fn [] (function))
         future (.scheduleWithFixedDelay executor function 0 interval TimeUnit/MILLISECONDS)]
     (swap! scheduled-futures assoc service-tag future)))
 


### PR DESCRIPTION
refs #222

I think the reason it worked in `lein repl` is because `System.out` and `*out*` are typically identical there.  However, when I ran `lein repl` in one terminal as a server and then `lein repl :connect PORT_NUMBER_HERE` in another, as a client, and then run the commands from the client `lein repl`... then I saw exactly the problematic behavior that's described for nrepl.el.

So this is just applying the binding conveyance hunch that Chas had, and it seems to work locally for me in the multi-lein-repl use case.

Cool feature, by the way - I like the colors!
