### PR TITLE
Update to dynapath 0.2.3.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -10,7 +10,7 @@
                  [utilize "0.2.3" :exclusions [org.clojure/clojure]]
                  [colorize "0.1.1" :exclusions [org.clojure/clojure]]
                  [org.clojure/tools.macro "0.1.5"]
-                 [dynapath "0.2.0"]
+                 [org.tcrawley/dynapath "0.2.3"]
                  [swiss-arrows "1.0.0"]
                  [org.clojure/tools.namespace "0.2.4"]
                  [slingshot "0.10.3"]


### PR DESCRIPTION
This is primarily to prevent conflicts with other deps that use the
zero-arity version of `all-classpath-urls`, which was introduced in
0.2.3, but also brings in a fix that prevents modification of the boot
class loader.

This change shouldn't impact Midje code at all, and all of the tests
pass for me with this change.
