### PR TITLE
Migrate to flare 0.2.8

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -15,7 +15,7 @@
                  [org.tcrawley/dynapath "0.2.3"]
                  [swiss-arrows "1.0.0" :exclusions [org.clojure/clojure]]
                  [org.clojure/tools.namespace "0.2.7"]
-                 [flare "0.2.5" :exclusions [org.clojure/clojure]]
+                 [flare "0.2.8" :exclusions [org.clojure/clojure]]
                  [slingshot "0.12.1"]
                  [commons-codec/commons-codec "1.10"]]
   :profiles {:dev {:dependencies [[slamhound "1.5.5"]

--- a/src/midje/emission/plugins/flare.clj
+++ b/src/midje/emission/plugins/flare.clj
@@ -5,40 +5,26 @@
 
 (defn emit-flare-lines [& args])
 
-(ecosystem/when-1-5+ 
+(ecosystem/when-1-5+
  (require '[flare.core :as flare])
  ;; Following code adapted from
  ;; https://raw.githubusercontent.com/andersfurseth/flare/master/src/flare/midje.clj
- 
+
  (defn report [reports]
    (when (seq reports)
      (util/emit-one-line "")
      (doseq [report reports]
        (util/emit-one-line report))))
 
- (defn generate-report-for-keyed-diff [[path diffs]]
-   (let [diffs (map flare/report diffs)
-         indent-diffs? (and (seq path) (< 1 (count diffs)))]
-     (-> diffs
-         (cond->> indent-diffs? (map #(str "  " %)))
-         flare/join-with-newlines
-         (cond->> (seq path) (str "in " (pr-str path) (if indent-diffs? "\n" " "))))))
-
  (defn generate-reports [diffs]
    ; (prn "Flare data: " diffs)
    ; (clojure.pprint/pprint diffs)
    (println "Flare output (experimental):")
-   (try
-     (->> diffs
-          flare/flatten-keys
-          sort
-          (map flare/generate-report-for-keyed-diff))
-     (catch Exception e)))
+   (flare/generate-reports diffs))
 
  (defn emit-flare-lines [failure-map]
    (when (= (:type failure-map) :actual-result-did-not-match-expected-value)
-     
-     (some-> (flare/diff (:expected-result failure-map) (:actual failure-map))
-             generate-reports
-             report)))
+      (some-> (flare/diff (:expected-result failure-map) (:actual failure-map))
+              generate-reports
+              report)))
 )


### PR DESCRIPTION
flare-0.2.8 brings improvements to string diffs, as well as fixes andersfurseth/flare#1.

I've also removed some references to functions I'd rather keep "private".