### PR TITLE
Mention midje-notifier in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,11 @@ Learning Midje
 [User guide](https://github.com/marick/Midje/wiki)    
 [Mailing list](http://groups.google.com/group/midje)
 
+Other Tools
+===========
+
+* [midje-notifier](https://github.com/glittershark/midje-notifier)
+
 Contributors
 ============
 * Sean T. Allen


### PR DESCRIPTION
In response to discussion on #221 I made a [little library][1] to provide notification center and libnotify output to Midje. I figured it'd be helpful if the README mentioned that existed.

[1]: https://github.com/glittershark/midje-notifier