### PR TITLE
fix race condition in record-fact-existence!

### DIFF
--- a/src/midje/data/compendium.clj
+++ b/src/midje/data/compendium.clj
@@ -135,8 +135,9 @@
 (defn record-fact-existence! [fact-function]
   (when (and (fact/allows-itself-to-be-recorded? fact-function)
              (config/user-wants-fact-to-be-recorded? fact-function))
-    (if-let [previous (previous-version @global fact-function)]
-      (swap! global remove-from previous))
+    (swap! global #(if-let [previous (previous-version % fact-function)]
+                     (remove-from % previous)
+                     %))
     (swap! global add-to fact-function))
   ;; Returning the fact-function is a kludge required by the
   ;; way tabular facts are parsed.


### PR DESCRIPTION
Previously, running several facts in parallel would occasionally cause
`AssertionError Assert failed: (not (neg? index-to-exclude))` in
`midje.data.compendium.Compendium/vector-remove`.

Turns out that was due to a race condition in
`midje.data.compendium/record-fact-existence!`.

For an example, se issue #328.