### PR TITLE
Replace :use with :require

### DIFF
--- a/leiningen/timings.clj
+++ b/leiningen/timings.clj
@@ -1,9 +1,9 @@
 (ns leiningen.timings
   (:refer-clojure :exclude [test])
-  (:use [leiningen.util.ns :only [namespaces-in-dir]]
-        [leiningen.test :only [*exit-after-tests*]]
-        [leiningen.compile :only [eval-in-project]]
-        [clojure.set :only [difference]]))
+  (:require [leiningen.util.ns :refer [namespaces-in-dir]]
+            [leiningen.test :refer [*exit-after-tests*]]
+            [leiningen.compile :refer [eval-in-project]]
+            [clojure.set :refer [difference]]))
 
 (defn require-namespaces-form [namespaces]
   `(let [array# (doall (map (fn [_#] (let [start# (.getTime (java.util.Date.))]

--- a/src/midje/checking/checkables.clj
+++ b/src/midje/checking/checkables.clj
@@ -1,15 +1,15 @@
 (ns ^{:doc "Core Midje functions that process expects and report on their results."} 
   midje.checking.checkables
-  (:use commons.clojure.core
-        midje.checking.core
-        [midje.util.exceptions :only [captured-throwable]]
-        midje.data.prerequisite-state
-        midje.util.laziness)
-  (:require [midje.config :as config]
+  (:require [commons.clojure.core :refer :all]
+            [midje.checking.core :refer :all]
+            [midje.config :as config]
             [midje.data.nested-facts :as nested-facts]
+            [midje.data.prerequisite-state :refer :all]
+            [midje.emission.api :as emit]
             [midje.emission.boundaries :as emission-boundary]
             [midje.parsing.1-to-explicit-form.parse-background :as parse-background]
-            [midje.emission.api :as emit]))
+            [midje.util.exceptions :refer [captured-throwable]]
+            [midje.util.laziness :refer :all]))
 
 
 (defn- minimal-failure-map

--- a/src/midje/checking/checkers/chatty.clj
+++ b/src/midje/checking/checkers/chatty.clj
@@ -1,11 +1,11 @@
 (ns ^{:doc "Checkers that explain more about a failure."}
   midje.checking.checkers.chatty
-  (:use commons.clojure.core
-        midje.checking.core
-        [midje.checking.checkers.util :only [named-as-call]]
-        [midje.checking.checkers.defining :only [as-checker]]
-        [midje.parsing.util.core :only [quoted?]])
-  (:require [midje.emission.colorize :as colorize]
+  (:require [commons.clojure.core :refer :all]
+            [midje.checking.checkers.defining :refer [as-checker]]
+            [midje.checking.checkers.util :refer [named-as-call]]
+            [midje.checking.core :refer :all]
+            [midje.emission.colorize :as colorize]
+            [midje.parsing.util.core :refer [quoted?]]
             [such.sequences :as seq]))
 
 ;; Note: checkers need to be exported in ../checkers.clj

--- a/src/midje/checking/checkers/collection.clj
+++ b/src/midje/checking/checkers/collection.clj
@@ -2,11 +2,16 @@
 
 (ns ^{:doc "Checkers for collections and strings."}
   midje.checking.checkers.collection
-  (:use commons.clojure.core
-        midje.checking.core
-      	[midje.checking.checkers collection-util util chatty defining collection-comparison]
-        [midje.util.exceptions :only [user-error]])
-  (:require [midje.util.pile :as pile]
+  (:require [commons.clojure.core :refer :all]
+            [midje.checking.core :refer :all]
+            [midje.checking.checkers
+             [collection-util :refer :all]
+             [util :refer :all]
+             [chatty :refer :all]
+             [defining :refer :all]
+             [collection-comparison :refer :all]]
+            [midje.util.exceptions :refer [user-error]]
+            [midje.util.pile :as pile]
             [such.sequences :as seq]))
 
 

--- a/src/midje/checking/checkers/collection_comparison.clj
+++ b/src/midje/checking/checkers/collection_comparison.clj
@@ -2,13 +2,17 @@
 
 (ns ^{:doc "Code to use to compare collections."}
   midje.checking.checkers.collection-comparison
-  (:use commons.clojure.core
-        midje.checking.core
-        [midje.checking.checkers collection-util util chatty defining])
-  (:require [clojure.string :as str]
-            [clojure.math.combinatorics :as comb]
-            [such.maps :as map]
-            [midje.util.pile :as pile]))
+  (:require [clojure.math.combinatorics :as comb]
+            [clojure.string :as str]
+            [commons.clojure.core :refer :all]
+            [midje.checking.core :refer :all]
+            [midje.checking.checkers
+             [collection-util :refer :all]
+             [util :refer :all]
+             [chatty :refer :all]
+             [defining :refer :all]]
+            [midje.util.pile :as pile]
+            [such.maps :as map]))
 
 ;; There is an annoying only-semi-similarity between maps and sequences.
 ;; These are the generic functions.

--- a/src/midje/checking/checkers/collection_diffs.clj
+++ b/src/midje/checking/checkers/collection_diffs.clj
@@ -2,8 +2,8 @@
 
 (ns midje.checking.checkers.collection-diffs
   "Checkers for collections and strings."
-  (:use commons.clojure.core)
-  (:require [midje.util.pile :as pile]
+  (:require [commons.clojure.core :refer :all]
+            [midje.util.pile :as pile]
             [midje.checking.checkers.collection :as old]
             [midje.checking.core :as core]
             flare.map)

--- a/src/midje/checking/checkers/collection_util.clj
+++ b/src/midje/checking/checkers/collection_util.clj
@@ -1,6 +1,6 @@
 (ns midje.checking.checkers.collection-util
-  (:use commons.clojure.core
-        midje.checking.core))
+  (:require [commons.clojure.core :refer :all]
+            [midje.checking.core :refer :all]))
 
 (defn same-lengths? [actual expected]
   (= (count actual) (count expected)))

--- a/src/midje/checking/checkers/combining.clj
+++ b/src/midje/checking/checkers/combining.clj
@@ -1,8 +1,8 @@
 (ns ^{:doc "Checkers that combine other checkers."}
   midje.checking.checkers.combining
-  (:use midje.checking.core
-        midje.checking.checkers.defining
-        midje.checking.checkers.chatty))
+  (:require [midje.checking.core :refer :all]
+            [midje.checking.checkers.defining :refer :all]
+            [midje.checking.checkers.chatty :refer :all]))
 
 (defn report-failure [actual checker-form result]
   (as-data-laden-falsehood {:actual actual

--- a/src/midje/checking/checkers/simple.clj
+++ b/src/midje/checking/checkers/simple.clj
@@ -1,11 +1,11 @@
 (ns midje.checking.checkers.simple
   "Prepackaged functions that perform common checks."
-  (:use commons.clojure.core
-        midje.checking.core
-        [midje.checking.checkers.defining :only [as-checker checker defchecker]]
-      	[midje.checking.checkers.util :only [named-as-call]]
-      	[midje.util.exceptions :only [captured-throwable?]])
-  (:require [commons.ns :as ns])
+  (:require [commons.clojure.core :refer :all]
+            [commons.ns :as ns]
+            [midje.checking.core :refer :all]
+            [midje.checking.checkers.defining :refer [as-checker checker defchecker]]
+            [midje.checking.checkers.util :refer [named-as-call]]
+            [midje.util.exceptions :refer [captured-throwable?]])
   (:import [midje.util.exceptions ICapturedThrowable]))
 
 ;;; DANGER: If you add a checker, add it to ../checkers.clj

--- a/src/midje/checking/checkers/util.clj
+++ b/src/midje/checking/checkers/util.clj
@@ -1,6 +1,6 @@
 (ns midje.checking.checkers.util
-  (:use commons.clojure.core)
-  (:require [midje.util.pile :as pile]))
+  (:require [commons.clojure.core :refer :all]
+            [midje.util.pile :as pile]))
 
 (defn named-as-call
   "Adds a string name that looks like a function call to

--- a/src/midje/checking/core.clj
+++ b/src/midje/checking/core.clj
@@ -1,8 +1,8 @@
 (ns midje.checking.core
   "Core ideas underlying all checking"
-  (:use commons.clojure.core)
-  ;; TODO: Shouldn't really have this dependency.
-  (:require [midje.emission.plugins.util :as names]
+  (:require [commons.clojure.core :refer :all]
+            ;; TODO: Shouldn't really have this dependency.
+            [midje.emission.plugins.util :as names]
             [such.sequences :as seq]))
 
 ;;; There is a notion of "extended falsehood", in which a false value may be a

--- a/src/midje/config.clj
+++ b/src/midje/config.clj
@@ -1,8 +1,8 @@
 (ns ^{:doc "Customizable configuration"}
   midje.config
-  (:use [midje.util.exceptions :only [user-error]])
   (:require [midje.emission.levels :as levels]
             [midje.util.ecosystem :as ecosystem]
+            [midje.util.exceptions :refer [user-error]]
             [midje.util.pile :as pile]
             [midje.data.fact :as fact]
             [commons.clojure.core :as core]

--- a/src/midje/data/compendium.clj
+++ b/src/midje/data/compendium.clj
@@ -2,10 +2,10 @@
             about a particular subject'. The Midje compendium contains
             the currently relevant facts."}
   midje.data.compendium
-  (:use [midje.util.exceptions :only [user-error]])
-  (:require [such.maps :as map]
+  (:require [midje.config :as config]
             [midje.data.fact :as fact]
-            [midje.config :as config]))
+            [midje.util.exceptions :refer [user-error]]
+            [such.maps :as map]))
 
 ;;; Facts are stored in a compendium:
 

--- a/src/midje/data/metaconstant.clj
+++ b/src/midje/data/metaconstant.clj
@@ -1,9 +1,9 @@
 (ns ^{:doc "A notation that avoids confusion between what’s essential 
             about data and what’s accidental. A stand in for constant data."}
   midje.data.metaconstant
-  (:use [midje.util.thread-safe-var-nesting :only [unbound-marker]])
   (:require [midje.util.ecosystem :as ecosystem]
-            [midje.util.exceptions :as exceptions]))
+            [midje.util.exceptions :as exceptions]
+            [midje.util.thread-safe-var-nesting :refer [unbound-marker]]))
 
 
 ;;; Metaconstants are built from special symbols, called "metaconstant symbol". Such symbols

--- a/src/midje/data/nested_facts.clj
+++ b/src/midje/data/nested_facts.clj
@@ -1,9 +1,9 @@
 (ns ^{:doc "During checking of a fact, this contains pointers to the facts that contain it,
             in outer-to-inner order. The fact itself is the `last` of the sequence."}
   midje.data.nested-facts
-  (:use commons.clojure.core)
-  (:require [midje.data.fact :as fact]
+  (:require [commons.clojure.core :refer :all]
             [clojure.string :as str]
+            [midje.data.fact :as fact]
             [midje.util.pile :as pile]))
 
 ;;; Note: this should probably be a lexically-scoped property of the

--- a/src/midje/data/prerequisite_state.clj
+++ b/src/midje/data/prerequisite_state.clj
@@ -1,19 +1,19 @@
 (ns ^{:doc "Maintain the use of namespace-specific prerequisites"}
   midje.data.prerequisite-state
-  (:use commons.clojure.core
-        midje.checking.core
-        [midje.util.thread-safe-var-nesting :only [with-altered-roots]]
-        [midje.emission.deprecation :only [deprecate]]
-        [midje.parsing.arrow-symbols])
   (:require [clojure.tools.macro :as macro]
-            [such.maps :as map]
-            [such.sequences :as seq]
+            [commons.clojure.core :refer :all]
+            [midje.checking.core :refer :all]
             [midje.config :as config]
-            [midje.util.pile :as pile]
             [midje.data.metaconstant :as metaconstant]
-            [midje.util.exceptions :as exceptions]
             [midje.emission.api :as emit]
-            [midje.parsing.2-to-lexical-maps.fakes :as parse-fakes])
+            [midje.emission.deprecation :refer [deprecate]]
+            [midje.parsing.arrow-symbols :refer :all]
+            [midje.parsing.2-to-lexical-maps.fakes :as parse-fakes]
+            [midje.util.exceptions :as exceptions]
+            [midje.util.pile :as pile]
+            [midje.util.thread-safe-var-nesting :refer [with-altered-roots]]
+            [such.maps :as map]
+            [such.sequences :as seq])
   (:import midje.data.metaconstant.Metaconstant))
 
 

--- a/src/midje/data/project_state.clj
+++ b/src/midje/data/project_state.clj
@@ -1,17 +1,17 @@
 (ns ^{:doc "What we know about the changing project file/namespace tree."}
   midje.data.project-state
-  (:use commons.clojure.core)
-  (:require [midje.emission.boundaries :as emission-boundary]
-            [midje.util.ecosystem :as ecosystem]
-            [midje.emission.colorize :as color]
+  (:require [clj-time.local :as time]
+            [clojure.java.io :as io]
+            [clojure.set]
+            [commons.clojure.core :refer :all]
             [midje.config :as config]
-            [midje.util.bultitude :as tude]
             [midje.emission.api :as emit]
-            [such.sequences :as seq]
-            [such.maps :as map])
-  (:require [clojure.java.io :as io]
-            [clj-time.local :as time]
-            clojure.set))
+            [midje.emission.boundaries :as emission-boundary]
+            [midje.emission.colorize :as color]
+            [midje.util.ecosystem :as ecosystem]
+            [midje.util.bultitude :as tude]
+            [such.maps :as map]
+            [such.sequences :as seq]))
 
 
 (require '[clojure.tools.namespace.repl :as nsrepl]

--- a/src/midje/doc.clj
+++ b/src/midje/doc.clj
@@ -1,9 +1,9 @@
 (ns ^{:doc "In-repl user documentation"}
   midje.doc
-  (:use commons.clojure.core)
-  (:require [midje.emission.colorize :as color]
-            [clojure.java.browse :as browse]
+  (:require [clojure.java.browse :as browse]
+            [commons.clojure.core :refer :all]
             [midje.config :as config]
+            [midje.emission.colorize :as color]
             [midje.util.ecosystem :as ecosystem]))
 
 (def appropriate? config/running-in-repl?)

--- a/src/midje/emission/api.clj
+++ b/src/midje/emission/api.clj
@@ -1,12 +1,12 @@
 (ns ^{:doc "Emissions change global state: the output and the pass/fail record."}
   midje.emission.api
-  (:use commons.clojure.core
-        [midje.util.thread-safe-var-nesting :only [with-altered-roots]])
-  (:require [midje.config :as config]
+  (:require [commons.clojure.core :refer :all]
+            [midje.config :as config]
             [midje.emission.clojure-test-facade :as ctf]
             [midje.emission.levels :as levels]
             [midje.emission.state :as state]
-            [midje.emission.plugins.silence :as silence]))
+            [midje.emission.plugins.silence :as silence]
+            [midje.util.thread-safe-var-nesting :refer [with-altered-roots]]))
 
 ;;; Level handling
 

--- a/src/midje/emission/deprecation.clj
+++ b/src/midje/emission/deprecation.clj
@@ -1,8 +1,8 @@
 (ns ^{:doc "Utilities to deprecate features."}
   midje.emission.deprecation
-  (:use midje.emission.util
-        [pointer.core :only [compile-time-fallback-position]])
-  (:require [midje.config :as config]))
+  (:require [midje.config :as config]
+            [midje.emission.util :refer :all]
+            [pointer.core :refer [compile-time-fallback-position]]))
 
 (def any-deprecations? (atom :uninitialized))
 (def deprecation-record (atom :uninitialized))

--- a/src/midje/emission/levels.clj
+++ b/src/midje/emission/levels.clj
@@ -1,7 +1,7 @@
 (ns ^{:doc "print levels"}
   midje.emission.levels
-  (:use commons.clojure.core
-        [midje.util.exceptions :only [user-error]]))
+  (:require [commons.clojure.core :refer :all]
+            [midje.util.exceptions :refer [user-error]]))
 
 
 (def level-names [:print-nothing :print-no-summary :print-normally :print-namespaces :print-facts])

--- a/src/midje/emission/plugins/default.clj
+++ b/src/midje/emission/plugins/default.clj
@@ -1,12 +1,12 @@
 (ns ^{:doc "The default for Midje output"}
   midje.emission.plugins.default
-  (:use midje.emission.util)
-  (:require [midje.emission.colorize :as color]
-            [midje.data.fact :as fact]
-            [midje.emission.state :as state]
+  (:require [midje.data.fact :as fact]
+            [midje.emission.colorize :as color]
             [midje.emission.plugins.util :as util]
             [midje.emission.plugins.silence :as silence]
             [midje.emission.plugins.default-failure-lines :as lines]
+            [midje.emission.state :as state]
+            [midje.emission.util :refer :all]
             [clojure.string :as str]))
 
 (defn fail [failure-map]

--- a/src/midje/emission/plugins/default_failure_lines.clj
+++ b/src/midje/emission/plugins/default_failure_lines.clj
@@ -1,10 +1,10 @@
 (ns ^{:doc "How the default emitter reports on failures"}
   midje.emission.plugins.default-failure-lines
-  (:use commons.clojure.core
-        midje.emission.plugins.util)
-  (:require [midje.util.ecosystem :as ecosystem]
+  (:require [clojure.string :as str]
+            [commons.clojure.core :refer :all]
             [flare.core :as flare]
-            [clojure.string :as str]))
+            [midje.emission.plugins.util :refer :all]
+            [midje.util.ecosystem :as ecosystem]))
 
 
 (defmulti messy-lines :type)

--- a/src/midje/emission/plugins/flare.clj
+++ b/src/midje/emission/plugins/flare.clj
@@ -1,6 +1,6 @@
 (ns midje.emission.plugins.flare
-  (:use commons.clojure.core)
-  (:require [midje.util.ecosystem :as ecosystem]
+  (:require [commons.clojure.core :refer :all]
+            [midje.util.ecosystem :as ecosystem]
             [midje.emission.plugins.util :as util]))
 
 (defn emit-flare-lines [& args])

--- a/src/midje/emission/plugins/junit.clj
+++ b/src/midje/emission/plugins/junit.clj
@@ -1,15 +1,15 @@
 (ns ^{:doc "JUnit formatter for Midje output"}
   midje.emission.plugins.junit
   (:import java.io.File)
-  (:use [midje.emission.util])
-  (:require [midje.data.fact :as fact]
+  (:require [clj-time.core :as time]
+            [clojure.string :as string]
+            [clojure.xml :as xml :only [emit-element]]
             [midje.config :as config]
+            [midje.data.fact :as fact]
+            [midje.emission.util :refer :all]
             [midje.emission.state :as state]
             [midje.emission.plugins.silence :as silence]
-            [midje.emission.plugins.default-failure-lines :as lines]
-            [clj-time.core :as time]
-            [clojure.string :as string]
-            [clojure.xml :as xml :only [emit-element]]))
+            [midje.emission.plugins.default-failure-lines :as lines]))
 
 
 ;; This plugin requires all emission api calls to be

--- a/src/midje/emission/plugins/progress.clj
+++ b/src/midje/emission/plugins/progress.clj
@@ -1,12 +1,12 @@
 (ns ^{:doc "Progress formatter for Midje output"}
   midje.emission.plugins.progress
-  (:use midje.emission.util)
   (:require [midje.emission.colorize :as color]
-            [midje.emission.state :as state]
             [midje.emission.plugins.util :as util]
             [midje.emission.plugins.silence :as silence]
             [midje.emission.plugins.default :as default]
-            [midje.emission.plugins.default-failure-lines :as lines]))
+            [midje.emission.plugins.default-failure-lines :as lines]
+            [midje.emission.state :as state]
+            [midje.emission.util :refer :all]))
 
 (defn- def-failure-cache []
  (defonce raw-failures-cache (atom [])))

--- a/src/midje/emission/plugins/tap.clj
+++ b/src/midje/emission/plugins/tap.clj
@@ -1,12 +1,12 @@
 (ns ^{:doc "TAP output. See http://testanything.org"}
   midje.emission.plugins.tap
-  (:use midje.emission.util)
-  (:require [midje.data.fact :as fact]
-            [midje.emission.state :as state]
+  (:require [clojure.string :as str]
+            [midje.data.fact :as fact]
             [midje.emission.plugins.util :as util]
             [midje.emission.plugins.silence :as silence]
             [midje.emission.plugins.default-failure-lines :as lines]
-            [clojure.string :as str]))
+            [midje.emission.state :as state]
+            [midje.emission.util :refer :all]))
 
 (def fact-counter (atom 0))
 

--- a/src/midje/emission/plugins/util.clj
+++ b/src/midje/emission/plugins/util.clj
@@ -1,8 +1,8 @@
 (ns ^{:doc "General purpose plugin utilities"}
   midje.emission.plugins.util
-  (:use commons.clojure.core
-        [clojure.repl :only [demunge]])
-  (:require [clojure.string :as str]
+  (:require [clojure.repl :refer [demunge]]
+            [clojure.string :as str]
+            [commons.clojure.core :refer :all]
             [midje.util.pile :as pile]
             [midje.emission.clojure-test-facade :as ctf]
             [midje.emission.colorize :as color]

--- a/src/midje/open_protocols.clj
+++ b/src/midje/open_protocols.clj
@@ -5,8 +5,8 @@
   currently faked out. If so, it uses that function definition instead of
   continuing on with its own implementation."}
   midje.open-protocols
-  (:use [midje.production-mode :only [user-desires-checking?]]
-        [midje.data.prerequisite-state :only [implements-a-fake?]]))
+  (:require [midje.data.prerequisite-state :refer [implements-a-fake?]]
+            [midje.production-mode :refer [user-desires-checking?]]))
 
 (defn- ^{:testable true } implementation?
   "Is this thing a protocol or a function definition?"

--- a/src/midje/parsing/0_to_fact_form/formulas.clj
+++ b/src/midje/parsing/0_to_fact_form/formulas.clj
@@ -1,16 +1,16 @@
 (ns ^{:doc "Midje's special blend of generative-style testing."}
   midje.parsing.0-to-fact-form.formulas
-  (:use commons.clojure.core
-        midje.parsing.util.core
-        [clojure.string :only [join]]
-        [clojure.walk :only [prewalk]])
-  (:require [midje.util.pile :as pile]
+  (:require [clojure.string :refer [join]]
+            [clojure.walk :refer [prewalk]]
+            [commons.clojure.core :refer :all]
+            [midje.emission.api :as emit]
+            [midje.emission.boundaries :as emission-boundary]
+            [midje.emission.state :as state]
+            [midje.emission.plugins.silence :as emission-silence]
+            [midje.parsing.util.core :refer :all]
             [midje.parsing.util.error-handling :as error]
             [midje.parsing.util.recognizing :as recognize]
-            [midje.emission.boundaries :as emission-boundary]
-            [midje.emission.api :as emit]
-            [midje.emission.state :as state]
-            [midje.emission.plugins.silence :as emission-silence]))
+            [midje.util.pile :as pile]))
 
 ;; Formulas work by running up to *num-trials* trials per formula.
 (def ^{:doc "The number of trials generated per formula."

--- a/src/midje/parsing/0_to_fact_form/tabular.clj
+++ b/src/midje/parsing/0_to_fact_form/tabular.clj
@@ -1,21 +1,21 @@
 (ns ^{:doc "A way to create multiple facts with the same template, but different data points."}
   midje.parsing.0-to-fact-form.tabular
-  (:use commons.clojure.core
-        midje.parsing.util.zip
-        [pointer.core :only [form-with-copied-line-numbers]]
-        [midje.emission.deprecation :only [deprecate]]
-        [midje.parsing.util.zip :only [skip-to-rightmost-leaf]]
-        [midje.data.metaconstant :only [metaconstant-symbol?]])
-(:require [clojure.string :as str]
-          [midje.util.pile :as pile]
-          [clojure.zip :as zip]
-          [midje.parsing.util.zip :as pzip]
-          [midje.parsing.1-to-explicit-form.facts :as parse-facts]
-          [midje.util.unify :as unify]
-          [midje.parsing.util.overrides :as override]
-          [midje.parsing.lexical-maps :as maps]
-          [midje.parsing.1-to-explicit-form.metadata :as metadata]
-          [midje.parsing.util.error-handling :as error]))
+  (:require [clojure.string :as str]
+            [clojure.zip :as zip]
+            [commons.clojure.core :refer :all]
+            [midje.data.metaconstant :refer [metaconstant-symbol?]]
+            [midje.emission.deprecation :refer [deprecate]]
+            [midje.parsing.1-to-explicit-form.facts :as parse-facts]
+            [midje.parsing.1-to-explicit-form.metadata :as metadata]
+            [midje.parsing.lexical-maps :as maps]
+            [midje.parsing.util.error-handling :as error]
+            [midje.parsing.util.overrides :as override]
+            [midje.parsing.util.zip :as pzip]
+            [midje.parsing.util.zip :refer :all]
+            [midje.parsing.util.zip :refer [skip-to-rightmost-leaf]]
+            [midje.util.pile :as pile]
+            [midje.util.unify :as unify]
+            [pointer.core :refer [form-with-copied-line-numbers]]))
 
 (defn- headings-rows+values [table locals]
   (letfn [(table-variable? [s]

--- a/src/midje/parsing/1_to_explicit_form/expects.clj
+++ b/src/midje/parsing/1_to_explicit_form/expects.clj
@@ -1,8 +1,8 @@
 (ns ^{:doc "Functions for working with explicit expect forms."}
   midje.parsing.1-to-explicit-form.expects
-  (:use midje.parsing.util.core
-        [midje.parsing.2-to-lexical-maps.expects :only [expect]])
   (:require [clojure.zip :as zip]
+            [midje.parsing.2-to-lexical-maps.expects :refer [expect]]
+            [midje.parsing.util.core :refer :all]
             [midje.parsing.util.zip :as pzip]
             [midje.parsing.util.overrides :as override]
             [midje.parsing.util.recognizing :as recognize]

--- a/src/midje/parsing/1_to_explicit_form/facts.clj
+++ b/src/midje/parsing/1_to_explicit_form/facts.clj
@@ -1,27 +1,26 @@
 (ns ^{:doc "Parsing facts."}
   midje.parsing.1-to-explicit-form.facts
-  (:use commons.clojure.core
-        midje.parsing.util.core
-        midje.parsing.arrow-symbols
-
-        [midje.parsing.1-to-explicit-form.expects :only [wrap-with-expect__then__at-rightmost-expect-leaf]]
-        [midje.parsing.1-to-explicit-form.prerequisites :only [insert-prerequisites-into-expect-form-as-fakes]]
-        [midje.parsing.1-to-explicit-form.metaconstants :only [predefine-metaconstants-from-form]]
-        [midje.util.laziness :only [eagerly]])
   (:require [clojure.zip :as zip]
-            [midje.parsing.expanded-symbols :as expanded-symbols]
-            [midje.parsing.util.zip :as pzip]
-            [midje.parsing.util.overrides :as override]
-            [pointer.core :as pointer]
-            [midje.parsing.util.error-handling :as error]
-            [midje.parsing.util.wrapping :as wrapping]
-            [midje.parsing.util.recognizing :as recognize]
-            [midje.parsing.1-to-explicit-form.parse-background :as parse-background]
-            [midje.parsing.1-to-explicit-form.metadata :as parse-metadata]
-            [midje.parsing.2-to-lexical-maps.fakes :as parse-fakes]
-            [midje.parsing.2-to-lexical-maps.expects :as parse-expects]
-            [midje.parsing.2-to-lexical-maps.folded-fakes :as parse-folded-fakes]
+            [commons.clojure.core :refer :all]
             [midje.data.compendium :as compendium]
+            [midje.parsing.1-to-explicit-form.expects :refer [wrap-with-expect__then__at-rightmost-expect-leaf]]
+            [midje.parsing.1-to-explicit-form.metaconstants :refer [predefine-metaconstants-from-form]]
+            [midje.parsing.1-to-explicit-form.metadata :as parse-metadata]
+            [midje.parsing.1-to-explicit-form.parse-background :as parse-background]
+            [midje.parsing.1-to-explicit-form.prerequisites :refer [insert-prerequisites-into-expect-form-as-fakes]]
+            [midje.parsing.2-to-lexical-maps.expects :as parse-expects]
+            [midje.parsing.2-to-lexical-maps.fakes :as parse-fakes]
+            [midje.parsing.2-to-lexical-maps.folded-fakes :as parse-folded-fakes]
+            [midje.parsing.arrow-symbols :refer :all]
+            [midje.parsing.expanded-symbols :as expanded-symbols]
+            [midje.parsing.util.core :refer :all]
+            [midje.parsing.util.error-handling :as error]
+            [midje.parsing.util.overrides :as override]
+            [midje.parsing.util.recognizing :as recognize]
+            [midje.parsing.util.wrapping :as wrapping]
+            [midje.parsing.util.zip :as pzip]
+            [midje.util.laziness :refer [eagerly]]
+            [pointer.core :as pointer]
             [midje.checking.facts :as fact-checking]))
 
                                 ;;; Fact processing

--- a/src/midje/parsing/1_to_explicit_form/future_facts.clj
+++ b/src/midje/parsing/1_to_explicit_form/future_facts.clj
@@ -1,11 +1,11 @@
 (ns ^{:doc "Parsing future-facts."}
   midje.parsing.1-to-explicit-form.future-facts
-  (:use midje.parsing.util.core)
-  (:require [midje.util.pile :as pile]
-            [pointer.core :as pointer]
-            [midje.data.nested-facts :as nested-facts]
+  (:require [midje.data.nested-facts :as nested-facts]
+            [midje.emission.api :as emit]
             [midje.parsing.1-to-explicit-form.metadata :as parse-metadata]
-            [midje.emission.api :as emit]))
+            [midje.parsing.util.core :refer :all]
+            [midje.util.pile :as pile]
+            [pointer.core :as pointer]))
 
 (defn parse [form]
   (let [lineno (reader-line-number form)

--- a/src/midje/parsing/1_to_explicit_form/metadata.clj
+++ b/src/midje/parsing/1_to_explicit_form/metadata.clj
@@ -1,9 +1,9 @@
 (ns ^{:doc "Parsing metadata as found in facts, around-facts, and tables"}
   midje.parsing.1-to-explicit-form.metadata
-  (:use commons.clojure.core
-        [midje.util.exceptions :only [user-error]])
-  (:require [such.random :as random]
-            [midje.parsing.util.recognizing :as recognize]))
+  (:require [commons.clojure.core :refer :all]
+            [midje.parsing.util.recognizing :as recognize]
+            [midje.util.exceptions :refer [user-error]]
+            [such.random :as random]))
 
 
 (def ^{:dynamic true} metadata-for-fact-group {})

--- a/src/midje/parsing/1_to_explicit_form/parse_background.clj
+++ b/src/midje/parsing/1_to_explicit_form/parse_background.clj
@@ -1,27 +1,27 @@
 (ns midje.parsing.1-to-explicit-form.parse-background
   "Handles the parsing of background forms. For the moment, this includes both
    state changes and fact-wide prerequisites."
-  (:use commons.clojure.core
-        midje.parsing.util.core
-        midje.parsing.util.zip
-        [midje.parsing.1-to-explicit-form.metaconstants :only [predefine-metaconstants-from-form]]
-        [midje.parsing.1-to-explicit-form.prerequisites :only [prerequisite-to-fake take-arrow-sequence]]
-        [midje.data.prerequisite-state :only [with-installed-fakes]]
-        [midje.util.laziness :only [eagerly]]
-        [midje.util.thread-safe-var-nesting :only [namespace-values-inside-out
-                                                   with-pushed-namespace-values]])
-  (:require [clojure.zip :as zip]
-            [such.sequences :as seq]
+  (:require [commons.clojure.core :refer :all]
+            [clojure.zip :as zip]
             [midje.config :as config]
-            [midje.util.pile :as pile]
-            [midje.util.unify :as unify]
-            [pointer.core :as pointer]
+            [midje.data.prerequisite-state :refer [with-installed-fakes]]
+            [midje.emission.api :as emit]
+            [midje.parsing.1-to-explicit-form.metaconstants :refer [predefine-metaconstants-from-form]]
+            [midje.parsing.1-to-explicit-form.prerequisites :refer [prerequisite-to-fake take-arrow-sequence]]
+            [midje.parsing.2-to-lexical-maps.data-fakes :as data-fakes]
+            [midje.parsing.2-to-lexical-maps.fakes :as fakes]
+            [midje.parsing.util.core :refer :all]
             [midje.parsing.util.error-handling :as error]
             [midje.parsing.util.recognizing :as recognize]
             [midje.parsing.util.wrapping :as wrapping]
-            [midje.parsing.2-to-lexical-maps.fakes :as fakes]
-            [midje.parsing.2-to-lexical-maps.data-fakes :as data-fakes]
-            [midje.emission.api :as emit]))
+            [midje.parsing.util.zip :refer :all]
+            [midje.util.laziness :refer [eagerly]]
+            [midje.util.pile :as pile]
+            [midje.util.thread-safe-var-nesting :refer [namespace-values-inside-out
+                                                        with-pushed-namespace-values]]
+            [midje.util.unify :as unify]
+            [pointer.core :as pointer]
+            [such.sequences :as seq]))
 
 (defn background-fakes []
   (namespace-values-inside-out :midje/background-fakes))

--- a/src/midje/parsing/1_to_explicit_form/prerequisites.clj
+++ b/src/midje/parsing/1_to_explicit_form/prerequisites.clj
@@ -1,17 +1,17 @@
 (ns ^{:doc "Functions for turning provideds into explicit fakes"}
   midje.parsing.1-to-explicit-form.prerequisites
-  (:use midje.parsing.util.core
-        midje.parsing.arrow-symbols
-        [midje.parsing.2-to-lexical-maps.fakes :only [fake]]
-        [midje.parsing.2-to-lexical-maps.data-fakes :only [data-fake]])
   (:require [clojure.zip :as zip]
-            [midje.parsing.util.zip :as pzip]
-            [midje.parsing.util.overrides :as override]
-            [pointer.core :as pointer]
-            [midje.parsing.util.error-handling :as error]
-            [midje.parsing.util.recognizing :as recognize]
             [midje.parsing.1-to-explicit-form.expects :as parse-expects]
-            [midje.util.ecosystem :as ecosystem]))
+            [midje.parsing.2-to-lexical-maps.data-fakes :refer [data-fake]]
+            [midje.parsing.2-to-lexical-maps.fakes :refer [fake]]
+            [midje.parsing.arrow-symbols :refer :all]
+            [midje.parsing.util.core :refer :all]
+            [midje.parsing.util.error-handling :as error]
+            [midje.parsing.util.overrides :as override]
+            [midje.parsing.util.recognizing :as recognize]
+            [midje.parsing.util.zip :as pzip]
+            [midje.util.ecosystem :as ecosystem]
+            [pointer.core :as pointer]))
 
 (defn prerequisite-to-fake [fake-body]
   (let [^Integer line-number (-> fake-body

--- a/src/midje/parsing/2_to_lexical_maps/data_fakes.clj
+++ b/src/midje/parsing/2_to_lexical_maps/data_fakes.clj
@@ -1,11 +1,11 @@
 (ns ^{:doc "=contains=> prereqisites"}
   midje.parsing.2-to-lexical-maps.data-fakes
-  (:use commons.clojure.core
-        midje.parsing.util.core
-        midje.parsing.arrow-symbols)
-  (:require [midje.parsing.lexical-maps :as lexical-maps]
-            [midje.parsing.util.error-handling :as error]
-            [midje.data.metaconstant :as metaconstant]))
+  (:require [commons.clojure.core :refer :all]
+            [midje.data.metaconstant :as metaconstant]
+            [midje.parsing.arrow-symbols :refer :all]
+            [midje.parsing.lexical-maps :as lexical-maps]
+            [midje.parsing.util.core :refer :all]
+            [midje.parsing.util.error-handling :as error]))
 
 (defn valid-pieces [[_data-fake_ metaconstant arrow contained & overrides :as form]]
   (cond (not (metaconstant/metaconstant-symbol? metaconstant))

--- a/src/midje/parsing/2_to_lexical_maps/expects.clj
+++ b/src/midje/parsing/2_to_lexical_maps/expects.clj
@@ -1,17 +1,17 @@
 (ns midje.parsing.2-to-lexical-maps.expects
   "generate a map for a particular checkable"
-  (:use commons.clojure.core
-        midje.parsing.util.core
-        [midje.parsing.arrow-symbols])
-  (:require [such.maps :as map]
-            [such.sequences :as seq]
+  (:require [commons.clojure.core :refer :all]
             [midje.data.nested-facts :as nested-facts]
+            [midje.emission.api :as emit]
+            [midje.parsing.2-to-lexical-maps.data-fakes :as parse-data-fakes]
+            [midje.parsing.2-to-lexical-maps.fakes :as parse-fakes]
+            [midje.parsing.arrow-symbols :refer :all]
+            [midje.parsing.lexical-maps :as lexical-maps]
+            [midje.parsing.util.core :refer :all]
             [midje.parsing.util.error-handling :as error]
             [midje.parsing.util.recognizing :as recognize]
-            [midje.parsing.lexical-maps :as lexical-maps]
-            [midje.parsing.2-to-lexical-maps.fakes :as parse-fakes]
-            [midje.parsing.2-to-lexical-maps.data-fakes :as parse-data-fakes]
-            [midje.emission.api :as emit]))
+            [such.maps :as map]
+            [such.sequences :as seq]))
 
 
 (defn expansion [call-form arrow expected-result fakes overrides]

--- a/src/midje/parsing/2_to_lexical_maps/fakes.clj
+++ b/src/midje/parsing/2_to_lexical_maps/fakes.clj
@@ -1,11 +1,11 @@
 (ns ^{:doc "An intermediate stage in the compilation of prerequisites."}
   midje.parsing.2-to-lexical-maps.fakes
-  (:use commons.clojure.core
-        midje.parsing.util.core
-        [midje.parsing.arrow-symbols])
-  (:require [midje.parsing.util.fnref :as fnref]
+  (:require [commons.clojure.core :refer :all]
+            [midje.parsing.arrow-symbols :refer :all]
+            [midje.parsing.lexical-maps :as lexical-maps]
+            [midje.parsing.util.core :refer :all]
             [midje.parsing.util.error-handling :as error]
-            [midje.parsing.lexical-maps :as lexical-maps]))
+            [midje.parsing.util.fnref :as fnref]))
 
 (defn tag-as-background-fake [fake]
   `(~@fake :background :background :times (range 0)))

--- a/src/midje/parsing/2_to_lexical_maps/folded_fakes.clj
+++ b/src/midje/parsing/2_to_lexical_maps/folded_fakes.clj
@@ -1,13 +1,13 @@
 (ns ^{:doc "Unfolding prerequisites like `(f (g 1)) => 3`"}
   midje.parsing.2-to-lexical-maps.folded-fakes
-  (:use midje.parsing.util.zip
-        [midje.checking.checkers.defining :only [checker? checker-makers]]
-        [midje.parsing.2-to-lexical-maps.fakes :only [fake]])
   (:require [clojure.zip :as zip]
-            [such.maps :as map]
-            [midje.util.pile :as pile]
+            [midje.checking.checkers.defining :refer [checker? checker-makers]]
+            [midje.parsing.2-to-lexical-maps.fakes :refer [fake]]
+            [midje.parsing.util.fnref :as fnref]
             [midje.parsing.util.recognizing :as recognize]
-            [midje.parsing.util.fnref :as fnref]))
+            [midje.parsing.util.zip :refer :all]
+            [midje.util.pile :as pile]
+            [such.maps :as map]))
 
 ;; Note that unfolding is done after prerequisites are converted to fakes. 
 

--- a/src/midje/parsing/3_from_lexical_maps/from_fake_maps.clj
+++ b/src/midje/parsing/3_from_lexical_maps/from_fake_maps.clj
@@ -1,11 +1,11 @@
 (ns ^{:doc "Generating functions that work on fake maps."}
   midje.parsing.3-from-lexical-maps.from-fake-maps
-  (:use commons.clojure.core
-        midje.checking.core
-        [midje.checking.checkers.defining :only [checker?]]
-        [midje.parsing.arrow-symbols])
-  (:require [midje.util.exceptions :as exceptions]
-            [midje.checkers :as checkers]))
+  (:require [commons.clojure.core :refer :all]
+            [midje.checkers :as checkers]
+            [midje.checking.core :refer :all]
+            [midje.checking.checkers.defining :refer [checker?]]
+            [midje.parsing.arrow-symbols :refer :all]
+            [midje.util.exceptions :as exceptions]))
 
 (defn- mkfn:arg-matcher
   "Based on an expected value, generates a function that returns

--- a/src/midje/parsing/lexical_maps.clj
+++ b/src/midje/parsing/lexical_maps.clj
@@ -1,11 +1,11 @@
 (ns midje.parsing.lexical-maps
   "checkable maps, redefine maps, failure maps"
-  (:use commons.clojure.core)
-  (:require [midje.data.nested-facts :as nested-facts]
-            [midje.parsing.util.fnref :as fnref]
-            [pointer.core :as pointer]
-            [midje.parsing.util.recognizing :as recognize]
+  (:require [commons.clojure.core :refer :all]
+            [midje.data.nested-facts :as nested-facts]
             [midje.parsing.3-from-lexical-maps.from-fake-maps :as from-fake-maps]
+            [midje.parsing.util.fnref :as fnref]
+            [midje.parsing.util.recognizing :as recognize]
+            [pointer.core :as pointer]
             [such.maps :as map]))
 
 

--- a/src/midje/parsing/other/arglists.clj
+++ b/src/midje/parsing/other/arglists.clj
@@ -1,10 +1,10 @@
 (ns ^{:doc "Parsing function argument lists"}
   midje.parsing.other.arglists
-  (:use commons.clojure.core
-        midje.parsing.util.core
-        [midje.util.exceptions :only [user-error]])
-  (:require [midje.emission.levels :as levels]
+  (:require [commons.clojure.core :refer :all]
             [midje.config :as config]
+            [midje.emission.levels :as levels]
+            [midje.parsing.util.core :refer :all]
+            [midje.util.exceptions :refer [user-error]]
             [midje.util.pile :as pile]
             [such.function-makers :as mkfn]
             [such.sequences :as seq]))

--- a/src/midje/parsing/util/error_handling.clj
+++ b/src/midje/parsing/util/error_handling.clj
@@ -1,9 +1,9 @@
 (ns midje.parsing.util.error-handling
   "Utility functions dealing with checking or tranforming forms or zippers."
-  (:use commons.clojure.core
-        [midje.util.exceptions :only [user-error-exception-lines]]
-        [pointer.core :only [form-position]])
-  (:require [midje.emission.api :as emit]))
+  (:require [commons.clojure.core :refer :all]
+            [midje.emission.api :as emit]
+            [midje.util.exceptions :refer [user-error-exception-lines]]
+            [pointer.core :refer [form-position]]))
 
 (def ^{:dynamic true} *wrap-count* 0)
 (def bail-out-of-parsing (gensym))

--- a/src/midje/parsing/util/fnref.clj
+++ b/src/midje/parsing/util/fnref.clj
@@ -1,7 +1,7 @@
 (ns midje.parsing.util.fnref
   "A fnref is the first symbol-or-var in a list. These utilities
    allow you to interpret it in multiple ways."
-  (:use commons.clojure.core))
+  (:require [commons.clojure.core :refer :all]))
 
 
 (defn classify-function-reference [reference]

--- a/src/midje/parsing/util/future_variants.clj
+++ b/src/midje/parsing/util/future_variants.clj
@@ -1,7 +1,7 @@
 (ns ^{:doc "A stupid whimsy that I must drag along with me forever"}
   midje.parsing.util.future-variants
-  (:use midje.parsing.util.core)
-  (:require [midje.util.pile :as pile]))
+  (:require [midje.parsing.util.core :refer :all]
+            [midje.util.pile :as pile]))
 
 (def future-prefixes ["future-" 
                       "pending-" 

--- a/src/midje/parsing/util/recognizing.clj
+++ b/src/midje/parsing/util/recognizing.clj
@@ -1,12 +1,12 @@
 (ns ^{:doc "Recognizing Midje forms"}
   midje.parsing.util.recognizing
-  (:use commons.clojure.core
-        midje.parsing.util.core
-        midje.parsing.arrow-symbols)
   (:require [clojure.zip :as zip]
+            [commons.clojure.core :refer :all]
+            [midje.parsing.arrow-symbols :refer :all]
+            [midje.parsing.util.core :refer :all]
+            [midje.parsing.util.future-variants :as future-variants]
             [midje.parsing.util.zip :as pzip]
-            [midje.util.pile :as pile]
-            [midje.parsing.util.future-variants :as future-variants]))
+            [midje.util.pile :as pile]))
 
 ;; Arrow groupings
 

--- a/src/midje/parsing/util/wrapping.clj
+++ b/src/midje/parsing/util/wrapping.clj
@@ -1,13 +1,13 @@
 (ns ^{:doc "midje.background uses these to wrap extra code around 
             :contents, :facts, or :expects"}
   midje.parsing.util.wrapping
-  (:use midje.parsing.util.core
-        [midje.util.thread-safe-var-nesting :only [namespace-values-inside-out 
-                                                   set-namespace-value
-                                                   with-pushed-namespace-values]])
-  (:require [clojure.zip :as zip] 
-            [such.sequences :as seq]
-  	        [midje.util.unify :as unify]))
+  (:require [clojure.zip :as zip]
+            [midje.parsing.util.core :refer :all]
+            [midje.util.thread-safe-var-nesting :refer [namespace-values-inside-out 
+                                                        set-namespace-value
+                                                        with-pushed-namespace-values]] 
+            [midje.util.unify :as unify]
+            [such.sequences :as seq]))
 
 
 (defn midje-wrapped

--- a/src/midje/repl.clj
+++ b/src/midje/repl.clj
@@ -1,24 +1,24 @@
 (ns midje.repl
   "Functions useful when using Midje in the repl or from the command line.
    See `midje-repl-help` for details."
-  (:use commons.clojure.core)
-  (:require midje.sweet
-            [such.function-makers :as mkfn]
-            [midje.doc :as doc]
-            [such.immigration :as immigrate]
-            [clojure.java.io :as io]
-            [midje.config :as config]
-            [midje.util.pile :as pile]
-            [midje.util.ecosystem :as ecosystem]
-            [midje.util.scheduling :as scheduling]
-            [midje.data.fact :as fact-data]
-            [midje.data.compendium :as compendium]
-            [midje.data.project-state :as project-state]
+  (:require [clojure.java.io :as io]
+            [commons.clojure.core :refer :all]
             [midje.checking.facts :as fact-checking]
-            [midje.parsing.other.arglists :as parsing]
+            [midje.config :as config]
+            [midje.data.compendium :as compendium]
+            [midje.data.fact :as fact-data]
+            [midje.data.project-state :as project-state]
+            [midje.doc :as doc]
+            [midje.emission.api :as emit]
             [midje.emission.boundaries :as emission-boundary]
             [midje.emission.colorize :as color]
-            [midje.emission.api :as emit]))
+            [midje.parsing.other.arglists :as parsing]
+            midje.sweet
+            [midje.util.ecosystem :as ecosystem]
+            [midje.util.pile :as pile]
+            [midje.util.scheduling :as scheduling]
+            [such.function-makers :as mkfn]
+            [such.immigration :as immigrate]))
 
 (fact-data/make-getters *ns* "fact-")
 

--- a/src/midje/shape_checkers.clj
+++ b/src/midje/shape_checkers.clj
@@ -1,10 +1,10 @@
 (ns midje.shape-checkers
   "Checkers that use structural-typing"
-  (:use commons.clojure.core)
-  (:require [such.immigration :as immigrate]
+  (:require [commons.clojure.core :refer :all]
             [midje.checking.core :as checking.core]
             [midje.checking.checkers.defining :refer [checker defchecker]]
-            [midje.util.ecosystem :refer [when-1-7+]]))
+            [midje.util.ecosystem :refer [when-1-7+]]
+            [such.immigration :as immigrate]))
 
 
 (when-1-7+

--- a/src/midje/sweet.clj
+++ b/src/midje/sweet.clj
@@ -10,9 +10,9 @@
   ;; The following lets us avoid a circular dependency. Sigh.
   (:require midje.parsing.1-to-explicit-form.future-facts)
 
-  (:use commons.clojure.core
-        midje.parsing.util.core
-        midje.production-mode)
+  (:require [commons.clojure.core :refer :all]
+            [midje.parsing.util.core :refer :all]
+            [midje.production-mode :refer :all])
   ;; For immigration
   (:require [midje.doc :as doc]
             midje.checking.checkables

--- a/src/midje/util/exceptions.clj
+++ b/src/midje/util/exceptions.clj
@@ -1,7 +1,7 @@
 (ns ^{:doc "Functions for Midje to deal elegantly with exceptions."}
   midje.util.exceptions
-  (:use [clojure.string :only [join]]
-        [midje.util.ecosystem :only [line-separator]]))
+  (:require [clojure.string :refer [join]]
+            [midje.util.ecosystem :refer [line-separator]]))
 
 
 ;;; Creating 

--- a/src/midje/util/laziness.clj
+++ b/src/midje/util/laziness.clj
@@ -1,6 +1,6 @@
 (ns midje.util.laziness
   "To evaluate a fact it needs to be eagerly evaluated."
-  (:use commons.clojure.core))
+  (:require [commons.clojure.core :refer :all]))
 
 
 (defn eagerly

--- a/src/midje/util/ordered_map.clj
+++ b/src/midje/util/ordered_map.clj
@@ -3,9 +3,9 @@
   `https://github.com/flatland/ordered`, because of a version conflict.
   That library is covered by the Eclipse Public License, V1.0, which
   you can find in Midje's root directory."
-  (:use [midje.util.ordered-common :only [change! Compactable compact]]
-        [midje.util.ordered-deftype :only [delegating-deftype]])
-  (:require [clojure.string :as s])
+  (:require [clojure.string :as s]
+            [midje.util.ordered-common :refer [change! Compactable compact]]
+            [midje.util.ordered-deftype :refer [delegating-deftype]])
   (:import (clojure.lang IPersistentMap
                          IPersistentCollection
                          IPersistentVector

--- a/src/midje/util/ordered_set.clj
+++ b/src/midje/util/ordered_set.clj
@@ -3,8 +3,8 @@
   `https://github.com/flatland/ordered`, because of a version conflict.
   That library is covered by the Eclipse Public License, V1.0, which
   you can find in Midje's root directory."
-  (:use [midje.util.ordered-common :only [Compactable compact change!]])
-  (:require [clojure.string :as s])
+  (:require [clojure.string :as s]
+            [midje.util.ordered-common :refer [Compactable compact change!]])
   (:import (clojure.lang IPersistentSet ITransientSet IEditableCollection
                          IPersistentMap ITransientMap ITransientAssociative
                          IPersistentVector ITransientVector

--- a/src/midje/util/pile.clj
+++ b/src/midje/util/pile.clj
@@ -1,8 +1,8 @@
 (ns midje.util.pile
   "Functions that are somewhat general purpose."
-  (:use commons.clojure.core)
-  (:use [midje.util.ordered-map :only [ordered-map]])
-  (:require [such.maps :as map]))
+  (:require [commons.clojure.core :refer :all]
+            [midje.util.ordered-map :refer [ordered-map]]
+            [such.maps :as map]))
 
 ;;; Named things
 

--- a/src/midje/util/unify.clj
+++ b/src/midje/util/unify.clj
@@ -1,7 +1,7 @@
 (ns ^{:doc "Unification is used in tabular and (against-)background code."}
   midje.util.unify
-  (:use [clojure.walk :only [prewalk]])
-  (:require [clojure.core.unify :as unify]))
+  (:require [clojure.core.unify :as unify]
+            [clojure.walk :refer [prewalk]]))
 
 (def unify unify/unify)
 

--- a/test-test-paths/integration/t_pretend.clj
+++ b/test-test-paths/integration/t_pretend.clj
@@ -1,5 +1,5 @@
 (ns integration.t-pretend
-  (:use midje.sweet))
+  (:require [midje.sweet :refer :all]))
 
 
 (fact "Look, ma! A failure" 1 => 2)

--- a/test/as_documentation/about_defrecord/using_as__plain_tests/specific.clj
+++ b/test/as_documentation/about_defrecord/using_as__plain_tests/specific.clj
@@ -2,9 +2,9 @@
 ;; implements a protocol, but doing that makes what's going on more clear.
 
 (ns as-documentation.about-defrecord.using-as--plain-tests.specific
-  (:use midje.sweet)
-  (:require [midje.util.ecosystem :as ecosystem])
-  (:require [as-documentation.about-defrecord.generic :as generic]))
+  (:require [midje.sweet :refer :all]
+            [midje.util.ecosystem :as ecosystem]
+            [as-documentation.about-defrecord.generic :as generic]))
 
 (fact "The generic function exists - it's a bound var"
   (bound? #'generic/bump) => true)

--- a/test/as_documentation/about_defrecord/using_as__plain_tests/test.clj
+++ b/test/as_documentation/about_defrecord/using_as__plain_tests/test.clj
@@ -2,8 +2,8 @@
 ;; `generic` namespace. So we must require them both.
 
 (ns as-documentation.about-defrecord.using-as--plain-tests.test
-  (:use midje.sweet)
-  (:require [as-documentation.about-defrecord.generic :as generic]
+  (:require [midje.sweet :refer :all]
+            [as-documentation.about-defrecord.generic :as generic]
             [as-documentation.about-defrecord.using-as--plain-tests.specific :as specific]))
 
 

--- a/test/as_documentation/about_defrecord/using_as__provided_tests/specific.clj
+++ b/test/as_documentation/about_defrecord/using_as__provided_tests/specific.clj
@@ -2,8 +2,8 @@
 ;; specially.
 
 (ns as-documentation.about-defrecord.using-as--provided-tests.specific
-  (:use midje.sweet)
-  (:require [midje.open-protocols :refer [defrecord-openly]])   ; <= this
+  (:require [midje.sweet :refer :all]
+            [midje.open-protocols :refer [defrecord-openly]])   ; <= this
   (:require [as-documentation.about-defrecord.generic :as generic]))
 
 ;; In contrast to the `defrecord` case (in `using_as__plain_tests/specific.clj`), the

--- a/test/as_documentation/about_defrecord/using_as__provided_tests/test.clj
+++ b/test/as_documentation/about_defrecord/using_as__provided_tests/test.clj
@@ -2,8 +2,8 @@
 ;; `generic` namespace. So we must require them both. That given, tests are unsurprising.
 
 (ns as-documentation.about-defrecord.using-as--provided-tests.test
-  (:use midje.sweet)
-  (:require [as-documentation.about-defrecord.generic :as generic]
+  (:require [midje.sweet :refer :all]
+            [as-documentation.about-defrecord.generic :as generic]
             [as-documentation.about-defrecord.using-as--provided-tests.specific :as specific]))
 
 (fact "testing the record works as in the `using_as__plain_tests` case"

--- a/test/as_documentation/about_defrecord/using_refer__plain_tests/specific.clj
+++ b/test/as_documentation/about_defrecord/using_refer__plain_tests/specific.clj
@@ -4,7 +4,7 @@
 ;; following the record definition require `refer`ences.
 
 (ns as-documentation.about-defrecord.using-refer--plain-tests.specific
-  (:use midje.sweet)
+  (:require [midje.sweet :refer :all])
   ;; This is all that's required in simple cases.
   (:require [as-documentation.about-defrecord.generic :refer [Numerical]])
   ;; However, if record definitions need to use other generic functions, or if

--- a/test/as_documentation/about_defrecord/using_refer__plain_tests/test.clj
+++ b/test/as_documentation/about_defrecord/using_refer__plain_tests/test.clj
@@ -2,7 +2,7 @@
 ;; namespace. But the generic functions come from the `generic` namespace.
 
 (ns as-documentation.about-defrecord.using-refer--plain-tests.test
-  (:use midje.sweet)
+  (:require [midje.sweet :refer :all])
   (:require [as-documentation.about-defrecord.using-refer--plain-tests.specific
              :refer [->Record]])
   (:require [as-documentation.about-defrecord.generic

--- a/test/as_documentation/about_defrecord/using_refer__provided_tests/specific.clj
+++ b/test/as_documentation/about_defrecord/using_refer__provided_tests/specific.clj
@@ -1,5 +1,5 @@
 (ns as-documentation.about-defrecord.using-refer--provided-tests.specific
-  (:use midje.sweet)
+  (:require [midje.sweet :refer :all])
   (:require [midje.open-protocols :refer [defrecord-openly]])   ; again, we use `defrecord-openly`
   (:require [as-documentation.about-defrecord.generic
              :refer [Numerical

--- a/test/as_documentation/about_defrecord/using_refer__provided_tests/test.clj
+++ b/test/as_documentation/about_defrecord/using_refer__provided_tests/test.clj
@@ -2,7 +2,7 @@
 ;; namespace. But the generic functions come from the `generic` namespace.
 
 (ns as-documentation.about-defrecord.using-refer--provided-tests.test
-  (:use midje.sweet)
+  (:require [midje.sweet :refer :all])
   (:require [as-documentation.about-defrecord.generic
              :refer [bump twice]])
   (:require [as-documentation.about-defrecord.using-refer--provided-tests.specific

--- a/test/as_documentation/about_privates/how_to_refer_to_privates_in_facts.clj
+++ b/test/as_documentation/about_privates/how_to_refer_to_privates_in_facts.clj
@@ -1,7 +1,7 @@
 (ns as-documentation.about-privates.how-to-refer-to-privates-in-facts
-  (:use midje.sweet
-        midje.util
-        midje.test-util))
+  (:require [midje.sweet :refer :all]
+            [midje.util :refer :all]
+            [midje.test-util :refer :all]))
 
 ;;; Suppose you want to test private vars. There are three ways to do it.
 

--- a/test/as_documentation/checkers/defining.clj
+++ b/test/as_documentation/checkers/defining.clj
@@ -1,6 +1,6 @@
 (ns as-documentation.checkers.defining
-  (:use midje.sweet
-        midje.test-util))
+  (:require [midje.sweet :refer :all]
+            [midje.test-util :refer :all]))
 
                 ;;; Checkers that do not take arguments
 

--- a/test/as_documentation/checkers/for_maps_and_records.clj
+++ b/test/as_documentation/checkers/for_maps_and_records.clj
@@ -1,6 +1,6 @@
 (ns as-documentation.checkers.for-maps-and-records
-  (:use midje.sweet
-        midje.test-util))
+  (:require [midje.sweet :refer :all]
+            [midje.test-util :refer :all]))
 
 
                                 ;;; Implications of extended equality

--- a/test/as_documentation/checkers/for_sequences.clj
+++ b/test/as_documentation/checkers/for_sequences.clj
@@ -1,6 +1,6 @@
 (ns as-documentation.checkers.for-sequences
-  (:use midje.sweet
-        midje.test-util))
+  (:require [midje.sweet :refer :all]
+            [midje.test-util :refer :all]))
 
                                 ;;; Ordinary equality
 

--- a/test/as_documentation/checkers/for_sets.clj
+++ b/test/as_documentation/checkers/for_sets.clj
@@ -1,6 +1,6 @@
 (ns as-documentation.checkers.for-sets
-  (:use midje.sweet
-        midje.test-util))
+  (:require [midje.sweet :refer :all]
+            [midje.test-util :refer :all]))
 
 
 (fact "`just` provides extended equality to set equality"

--- a/test/as_documentation/configuration.clj
+++ b/test/as_documentation/configuration.clj
@@ -1,6 +1,6 @@
 (ns as-documentation.configuration
-  (:use midje.sweet
-        midje.test-util))
+  (:require [midje.sweet :refer :all]
+            [midje.test-util :refer :all]))
 
 
 ;;; To change configuration settings for your whole project, you use

--- a/test/as_documentation/fact_groups.clj
+++ b/test/as_documentation/fact_groups.clj
@@ -1,7 +1,7 @@
 (ns as-documentation.fact-groups
-  (:use midje.repl
-        midje.test-util)
-  (:require [midje.config :as config]))
+  (:require [midje.config :as config]
+            [midje.repl :refer :all]
+            [midje.test-util :refer :all]))
 
 ;;; Fact groups are used to supply metadata to the enclosed top-level facts. 
 ;;; For example, here are two facts that would cause failures if checked.

--- a/test/as_documentation/facts.clj
+++ b/test/as_documentation/facts.clj
@@ -1,7 +1,7 @@
 (ns as-documentation.facts
-  (:use midje.sweet
-        midje.test-util)
-  (:require [midje.config :as config]))
+  (:require [midje.config :as config]
+            [midje.sweet :refer :all]
+            [midje.test-util :refer :all]))
 
 ;; Midje's test suite is configured not to show some output that's demonstrated here.
 ;; This resets Midje's setting back to the default. 

--- a/test/as_documentation/metaconstants.clj
+++ b/test/as_documentation/metaconstants.clj
@@ -1,5 +1,7 @@
 (ns as-documentation.metaconstants
-  (:use [midje sweet test-util]))
+  (:require [midje
+             [sweet :refer :all]
+             [test-util :refer :all]]))
 
 ;;;                             THE BASICS
 

--- a/test/as_documentation/prerequisites/aaaaaa_the_basics.clj
+++ b/test/as_documentation/prerequisites/aaaaaa_the_basics.clj
@@ -1,6 +1,6 @@
 (ns as-documentation.prerequisites.aaaaaa-the-basics
-  (:use midje.sweet
-        midje.test-util))
+  (:require [midje.sweet :refer :all]
+            [midje.test-util :refer :all]))
                                 ;;; The Basics
 
 ;; One development path is to work top-down and use the `provided`

--- a/test/as_documentation/prerequisites/fact_wide.clj
+++ b/test/as_documentation/prerequisites/fact_wide.clj
@@ -1,5 +1,5 @@
 (ns as-documentation.prerequisites.fact-wide
-  (:use midje.sweet))
+  (:require [midje.sweet :refer :all]))
 
 ;;; Here is a simple motivating example. Suppose you have a predicate `pilot-ready?` that
 ;;; depends on other predicates. 

--- a/test/as_documentation/prerequisites/partial.clj
+++ b/test/as_documentation/prerequisites/partial.clj
@@ -1,7 +1,7 @@
 (ns as-documentation.prerequisites.partial
-  (:use midje.sweet
-        midje.test-util)
-  (:require [midje.config :as config]))
+  (:require [midje.config :as config]
+            [midje.sweet :refer :all]
+            [midje.test-util :refer :all]))
 
 ;; Sometimes the prerequisite function already exists. What should
 ;; happen if there's no prerequisite for a particular argument list?

--- a/test/as_documentation/prerequisites/streaming_with_exceptions.clj
+++ b/test/as_documentation/prerequisites/streaming_with_exceptions.clj
@@ -1,5 +1,5 @@
 (ns as-documentation.prerequisites.streaming-with-exceptions
-  (:use midje.sweet))
+  (:require [midje.sweet :refer :all]))
 
 ;; By treating the correctness of functions as facts depending on
 ;; prerequisites, we can test handling of a stream of values that

--- a/test/as_documentation/prerequisites/used_with_protocols.clj
+++ b/test/as_documentation/prerequisites/used_with_protocols.clj
@@ -1,7 +1,7 @@
 (ns as-documentation.prerequisites.used-with-protocols
-  (:use midje.sweet
-        midje.test-util
-        midje.open-protocols))
+  (:require [midje.sweet :refer :all]
+            [midje.test-util :refer :all]
+            [midje.open-protocols :refer :all]))
 
 ;;; Clojure inlines deftype and defrecord functions for speed. Consider this protocol and record:
 

--- a/test/as_documentation/prerequisites/variant_arrows.clj
+++ b/test/as_documentation/prerequisites/variant_arrows.clj
@@ -1,8 +1,8 @@
 (ns as-documentation.prerequisites.variant-arrows
-  (:use midje.sweet
-        midje.util
-        midje.test-util
-        midje.util.exceptions))
+  (:require [midje.sweet :refer :all]
+            [midje.util :refer :all]
+            [midje.test-util :refer :all]
+            [midje.util.exceptions :refer :all]))
   
 
 ;; A typical called/caller relationship. The key thing is that

--- a/test/as_documentation/production_mode.clj
+++ b/test/as_documentation/production_mode.clj
@@ -1,5 +1,5 @@
 (ns as-documentation.production-mode
-  (:use midje.sweet))
+  (:require [midje.sweet :refer :all]))
 
 ;;; People sometimes intermix facts with production code. When you actually deploy the production code,
 ;;; you may not want the Midje facts checked at load time. "Production mode" prevents that.

--- a/test/as_documentation/setup_and_teardown.clj
+++ b/test/as_documentation/setup_and_teardown.clj
@@ -1,6 +1,6 @@
 (ns as-documentation.setup-and-teardown
-  (:use midje.sweet
-        midje.test-util))
+  (:require [midje.sweet :refer :all]
+            [midje.test-util :refer :all]))
 
 (def state (atom nil))
 

--- a/test/as_documentation/sketch_for_background_replacement.clj
+++ b/test/as_documentation/sketch_for_background_replacement.clj
@@ -1,6 +1,6 @@
 (ns as-documentation.sketch-for-background-replacement
-  (:use midje.sweet
-        midje.test-util))
+  (:require [midje.sweet :refer :all]
+            [midje.test-util :refer :all]))
 
 
 ;;; THESE ARE SKETCHES TOWARD A POSSIBLE FUTURE FEATURE.

--- a/test/as_documentation/tabular_facts.clj
+++ b/test/as_documentation/tabular_facts.clj
@@ -1,6 +1,6 @@
 (ns as-documentation.tabular-facts
-  (:use midje.repl
-        midje.test-util))
+  (:require [midje.repl :refer :all]
+            [midje.test-util :refer :all]))
 
 ;;; When you have many similar tests, you can use *tabular facts* to
 ;;; clarify what's special about each test. Here, for example, is a tabular

--- a/test/behaviors/background_nesting/t_background_command.clj
+++ b/test/behaviors/background_nesting/t_background_command.clj
@@ -1,8 +1,7 @@
 (ns behaviors.background_nesting.t-background-command
-  (:use clojure.test)
-  (:use [midje.sweet])
-  (:use [midje.test-util])
-)
+  (:require [clojure.test :refer :all]
+            [midje.sweet :refer :all]
+            [midje.test-util :refer :all]))
 
 ;; This is a separate file because we're making namespace-wide changes
 

--- a/test/behaviors/background_nesting/t_background_command_no_deftest.clj
+++ b/test/behaviors/background_nesting/t_background_command_no_deftest.clj
@@ -1,8 +1,7 @@
 (ns behaviors.background_nesting.t-background-command-no-deftest
-  (:use clojure.test)
-  (:use [midje.sweet])
-  (:use [midje.test-util])
-)
+  (:require [clojure.test :refer :all]
+            [midje.sweet :refer :all]
+            [midje.test-util :refer :all]))
 
 ;; This is a separate file because we're making namespace-wide changes
 

--- a/test/behaviors/background_nesting/t_exception.clj
+++ b/test/behaviors/background_nesting/t_exception.clj
@@ -1,7 +1,6 @@
 (ns behaviors.background-nesting.t-exception
-  (:use clojure.test)
-  (:use [midje.sweet])
-)
+  (:require [clojure.test :refer :all]
+            [midje.sweet :refer :all]))
 
 ;; This is a separate file because we're making namespace-wide changes
 

--- a/test/behaviors/background_nesting/t_left_to_right.clj
+++ b/test/behaviors/background_nesting/t_left_to_right.clj
@@ -1,8 +1,7 @@
 (ns behaviors.background-nesting.t-left-to-right
-  (:use clojure.test)
-  (:use [midje.sweet])
-  (:use [midje.test-util])
-)
+  (:require [clojure.test :refer :all]
+            [midje.sweet :refer :all]
+            [midje.test-util :refer :all]))
 
 ;; This is a separate file because we're making namespace-wide changes
 

--- a/test/behaviors/background_nesting/t_outside.clj
+++ b/test/behaviors/background_nesting/t_outside.clj
@@ -1,8 +1,7 @@
 (ns behaviors.background-nesting.t-outside
-  (:use clojure.test)
-  (:use [midje.sweet])
-  (:use [midje.test-util])
-)
+  (:require [clojure.test :refer :all]
+            [midje.sweet :refer :all]
+            [midje.test-util :refer :all]))
 
 ;; This is a separate file because we're making namespace-wide changes
 

--- a/test/behaviors/background_nesting/t_shadowing.clj
+++ b/test/behaviors/background_nesting/t_shadowing.clj
@@ -1,6 +1,8 @@
 (ns behaviors.background-nesting.t-shadowing
-  (:use clojure.test
-        [midje sweet test-util]))
+  (:require [clojure.test :refer :all]
+            [midje
+             [sweet :refer :all]
+             [test-util :refer :all]]))
 
 ;; This is a separate file because we're making namespace-wide changes
 

--- a/test/behaviors/background_nesting/t_shadowing_outside_background.clj
+++ b/test/behaviors/background_nesting/t_shadowing_outside_background.clj
@@ -1,8 +1,7 @@
 (ns behaviors.background-nesting.t-shadowing-outside-background
-  (:use clojure.test)
-  (:use [midje.sweet])
-  (:use [midje.test-util])
-)
+  (:require [clojure.test :refer :all]
+            [midje.sweet :refer :all]
+            [midje.test-util :refer :all]))
 
 ;; This is a separate file because we're making namespace-wide changes
 

--- a/test/behaviors/background_nesting/t_three_levels.clj
+++ b/test/behaviors/background_nesting/t_three_levels.clj
@@ -1,8 +1,7 @@
 (ns behaviors.background-nesting.t-three-levels
-  (:use clojure.test)
-  (:use [midje.sweet])
-  (:use [midje.test-util])
-  )
+  (:require [clojure.test :refer :all]
+            [midje.sweet :refer :all]
+            [midje.test-util :refer :all]))
 
 ;; This is a separate file because we're making namespace-wide changes
 

--- a/test/behaviors/background_nesting/t_three_levels_outside.clj
+++ b/test/behaviors/background_nesting/t_three_levels_outside.clj
@@ -1,8 +1,7 @@
 (ns behaviors.background-nesting.t-three-levels-outside
-  (:use clojure.test)
-  (:use [midje.sweet])
-  (:use [midje.test-util])
-  )
+  (:require [clojure.test :refer :all]
+            [midje.sweet :refer :all]
+            [midje.test-util :refer :all]))
 
 ;; This is a separate file because we're making namespace-wide changes
 

--- a/test/behaviors/background_nesting/t_without_deftest.clj
+++ b/test/behaviors/background_nesting/t_without_deftest.clj
@@ -1,8 +1,7 @@
 (ns behaviors.background_nesting.t-without-deftest
-  (:use clojure.test)
-  (:use [midje.sweet])
-  (:use [midje.test-util])
-)
+  (:require [clojure.test :refer :all]
+            [midje.sweet :refer :all]
+            [midje.test-util :refer :all]))
 
 ;; This is a separate file because we're making namespace-wide changes
 

--- a/test/behaviors/folded_prerequisites_and_namespaces/t_using_namespace.clj
+++ b/test/behaviors/folded_prerequisites_and_namespaces/t_using_namespace.clj
@@ -1,8 +1,8 @@
 (ns behaviors.folded-prerequisites-and-namespaces.t-using-namespace
-  (:use [clojure.test]
-        [midje.sweet]
-        [behaviors.folded-prerequisites-and-namespaces.using-namespace])
-  (:require [behaviors.folded-prerequisites-and-namespaces.source-namespace :as x]))
+  (:require [clojure.test :refer :all]
+            [midje.sweet :refer :all]
+            [behaviors.folded-prerequisites-and-namespaces.using-namespace :refer :all]
+            [behaviors.folded-prerequisites-and-namespaces.source-namespace :as x]))
 
 (deftest test-something
   (fact

--- a/test/behaviors/t_canary.clj
+++ b/test/behaviors/t_canary.clj
@@ -4,8 +4,8 @@
 ;;; to annoy.
 
 (ns behaviors.t-canary
-  (:use [midje.sweet])
-  (:use [midje.test-util]))
+  (:require [midje.sweet :refer :all]
+            [midje.test-util :refer :all]))
 
 
 (unfinished favorite-animal)

--- a/test/behaviors/t_default_prerequisites.clj
+++ b/test/behaviors/t_default_prerequisites.clj
@@ -1,5 +1,7 @@
 (ns behaviors.t-default-prerequisites
-  (:use [midje sweet test-util]))
+  (:require [midje
+             [sweet :refer :all]
+             [test-util :refer :all]]))
 
 (defn calls-nothing [])
 (unfinished unused)

--- a/test/behaviors/t_fact_groups.clj
+++ b/test/behaviors/t_fact_groups.clj
@@ -1,6 +1,7 @@
 (ns behaviors.t-fact-groups
-  (:use midje.sweet midje.test-util)
-  (:require [midje.repl :as repl]
+  (:require [midje.sweet :refer :all]
+            [midje.test-util :refer :all]
+            [midje.repl :as repl]
             [midje.config :as config]))
 
 (repl/forget-facts *ns*)

--- a/test/behaviors/t_formulas.clj
+++ b/test/behaviors/t_formulas.clj
@@ -1,9 +1,9 @@
 (ns behaviors.t-formulas
-  (:use midje.test-util
-        midje.sweet
-        midje.util.ecosystem
-        [midje.parsing.0-to-fact-form.formulas :only [*num-trials* with-num-trials]] )
-  (:require [midje.config :as config]))
+  (:require [midje.config :as config]
+            [midje.test-util :refer :all]
+            [midje.sweet :refer :all]
+            [midje.util.ecosystem :refer :all]
+            [midje.parsing.0-to-fact-form.formulas :refer [*num-trials* with-num-trials]]))
 
 ;;;; Formulas
 

--- a/test/behaviors/t_isolated_metaconstants.clj
+++ b/test/behaviors/t_isolated_metaconstants.clj
@@ -1,5 +1,5 @@
 (ns behaviors.t-isolated-metaconstants
-  (:use [midje sweet]))
+  (:require [midje.sweet :refer :all]))
 
 
 (defn verify-service [service]

--- a/test/behaviors/t_lazy_evaluation_cases.clj
+++ b/test/behaviors/t_lazy_evaluation_cases.clj
@@ -1,7 +1,9 @@
 (ns behaviors.t-lazy-evaluation-cases
-  (:use [midje.sweet]
-        [midje.util laziness thread-safe-var-nesting]
-        [midje.test-util]))
+  (:require [midje.sweet :refer :all]
+            [midje.util
+             [laziness :refer :all]
+             [thread-safe-var-nesting :refer :all]]
+            [midje.test-util :refer :all]))
 
 (unfinished triple)
 

--- a/test/behaviors/t_macros.clj
+++ b/test/behaviors/t_macros.clj
@@ -1,5 +1,7 @@
 (ns behaviors.t-macros
-  (:use [midje sweet test-util]))
+  (:require [midje
+             [sweet :refer :all]
+             [test-util :refer :all]]))
 
 ;; Example from wiki
 (defmacro my-if [test true-branch false-branch]

--- a/test/behaviors/t_metaconstant_compilation.clj
+++ b/test/behaviors/t_metaconstant_compilation.clj
@@ -1,5 +1,5 @@
 (ns behaviors.t-metaconstant-compilation
-  (:use [midje sweet]))
+  (:require [midje.sweet :refer :all]))
 
 ;;; Because metaconstants are auto-defined, a file without `metaconstants`
 ;;; will fail AOT compilation. 

--- a/test/behaviors/t_setup_teardown.clj
+++ b/test/behaviors/t_setup_teardown.clj
@@ -1,7 +1,6 @@
 (ns behaviors.t-setup-teardown
-  (:use [midje.sweet])
-  (:use [midje.test-util])
-)
+  (:require [midje.sweet :refer :all]
+            [midje.test-util :refer :all]))
 
 (def test-atom (atom 33))
 (fact

--- a/test/behaviors/t_unfinished.clj
+++ b/test/behaviors/t_unfinished.clj
@@ -1,5 +1,7 @@
 (ns behaviors.t-unfinished
-  (:use [midje sweet test-util]))
+  (:require [midje
+             [sweet :refer :all]
+             [test-util :refer :all]]))
 
 (unfinished backing-function)
 

--- a/test/implementation/checking/checkers/fim_collection_diffs.clj
+++ b/test/implementation/checking/checkers/fim_collection_diffs.clj
@@ -1,6 +1,7 @@
 (ns implementation.checking.checkers.fim-collection-diffs (:require [midje.checking.checkers.collection-diffs :as subject])
-  (:use midje.sweet midje.test-util)
-  (:require [midje.checking.core :as core])
+  (:require [midje.sweet :refer :all]
+            [midje.test-util :refer :all]
+            [midje.checking.core :as core])
   (:import [flare.map MapKeysDiff]
            [flare.atom AtomDiff]))
 

--- a/test/implementation/checking/fim_facts.clj
+++ b/test/implementation/checking/fim_facts.clj
@@ -1,8 +1,9 @@
 (ns implementation.checking.fim-facts
   (:require [midje.checking.facts :as subject]
             [midje.config :as config]
-            [such.metadata :as meta])
-  (:use midje.sweet midje.test-util))
+            [midje.sweet :refer :all]
+            [midje.test-util :refer :all]
+            [such.metadata :as meta]))
 
 
 (def ^:dynamic record)

--- a/test/implementation/emission/plugins/fim_flare.clj
+++ b/test/implementation/emission/plugins/fim_flare.clj
@@ -1,6 +1,8 @@
 (ns implementation.emission.plugins.fim-flare (:require [midje.emission.plugins.flare :as subject])
-    (:use midje.sweet midje.test-util midje.util)
-    (:require [flare.core :as core]))
+    (:require [midje.sweet :refer :all]
+              [midje.test-util :refer :all]
+              [midje.util :refer :all]
+              [flare.core :as core]))
 
 (def f #(subject/generate-reports (core/diff %2 %1)))
 

--- a/test/implementation/fim_open_protocols.clj
+++ b/test/implementation/fim_open_protocols.clj
@@ -1,8 +1,8 @@
 (ns implementation.fim-open-protocols
-  (:use midje.open-protocols
-        midje.sweet
-        midje.test-util
-        midje.util))
+  (:require [midje.open-protocols :refer :all]
+            [midje.sweet :refer :all]
+            [midje.test-util :refer :all]
+            [midje.util :refer :all]))
 (expose-testables midje.open-protocols)
 
 (fact "can distinguish a protocol/interface name from a function implementation"

--- a/test/implementation/fim_shape_checkers.clj
+++ b/test/implementation/fim_shape_checkers.clj
@@ -1,7 +1,8 @@
 (ns implementation.fim-shape-checkers
-  (:require [midje.shape-checkers :as subject])
-  (:use midje.sweet midje.test-util)
-  (:require [midje.checking.core :as core]
+  (:require [midje.shape-checkers :as subject]
+            [midje.sweet :refer :all]
+            [midje.test-util :refer :all]
+            [midje.checking.core :as core]
             [midje.util.ecosystem :refer [when-1-7+]]))
 
 (when-1-7+

--- a/test/implementation/line_numbers/fim_background_parsing.clj
+++ b/test/implementation/line_numbers/fim_background_parsing.clj
@@ -1,6 +1,6 @@
 (ns implementation.line-numbers.fim-background-parsing
-  (:use midje.sweet
-        midje.test-util))
+  (:require [midje.sweet :refer :all]
+            [midje.test-util :refer :all]))
 
 ;; Check that errors are reported with the correct line numbers. There's one check for each
 ;; place where line numbers are reported.

--- a/test/implementation/line_numbers/fim_check_failures.clj
+++ b/test/implementation/line_numbers/fim_check_failures.clj
@@ -1,8 +1,8 @@
 (ns implementation.line-numbers.fim-check-failures
-  (:use midje.sweet
-        clojure.test
-        midje.test-util)
-  (:require [midje.config :as config]
+  (:require [midje.sweet :refer :all]
+            [clojure.test :refer :all]
+            [midje.test-util :refer :all]
+            [midje.config :as config]
             [midje.emission.clojure-test-facade :as ctf]))
 
 (defn f [n] n)

--- a/test/implementation/line_numbers/fim_check_parsing.clj
+++ b/test/implementation/line_numbers/fim_check_parsing.clj
@@ -1,6 +1,6 @@
 (ns implementation.line-numbers.fim-check-parsing
-  (:use midje.sweet
-        midje.test-util))
+  (:require [midje.sweet :refer :all]
+            [midje.test-util :refer :all]))
 
 ;; Check that errors are reported with the correct line numbers. There's one check for each
 ;; place where line numbers are reported.

--- a/test/implementation/line_numbers/fim_deftest.clj
+++ b/test/implementation/line_numbers/fim_deftest.clj
@@ -1,8 +1,8 @@
 (ns implementation.line-numbers.fim-deftest
-  (:use clojure.test
-        midje.sweet
-        midje.test-util)
-  (:require [midje.emission.clojure-test-facade :as ctf]
+  (:require [clojure.test :refer :all]
+            [midje.sweet :refer :all]
+            [midje.test-util :refer :all]
+            [midje.emission.clojure-test-facade :as ctf]
             [midje.emission.state :as state]
             [midje.config :as config]))
 

--- a/test/implementation/line_numbers/fim_numbers_and_namespaces.clj
+++ b/test/implementation/line_numbers/fim_numbers_and_namespaces.clj
@@ -1,8 +1,7 @@
 (ns implementation.line-numbers.fim-numbers-and-namespaces
-  (:require
-   [midje.config :as config])
-  (:use midje.sweet
-        midje.test-util))
+  (:require [midje.config :as config]
+            [midje.sweet :refer :all]
+            [midje.test-util :refer :all]))
 
 ; The namespace of the test should appear in test failure report
 
@@ -16,8 +15,8 @@
        (f) => -3
        (provided (g) => 88))
      (fact
-       @fact-output => #".clj:17\s+implementation.line-numbers.fim-numbers-and-namespaces"
-       @fact-output => #".clj:16\s+implementation.line-numbers.fim-numbers-and-namespaces")))
+       @fact-output => #".clj:16\s+implementation.line-numbers.fim-numbers-and-namespaces"
+       @fact-output => #".clj:15\s+implementation.line-numbers.fim-numbers-and-namespaces")))
 
   (config/with-augmented-config {:visible-failure-namespace false}
     (capturing-failure-output
@@ -25,6 +24,6 @@
        (f) => -3
        (provided (g) => 88))
      (fact
-       @fact-output => #".clj:26"
-       @fact-output =not=> #"clj:26\s+implementation.line-numbers.fim-numbers-and-namespaces"
-       @fact-output => #".clj:25"))))
+       @fact-output => #".clj:25"
+       @fact-output =not=> #"clj:25\s+implementation.line-numbers.fim-numbers-and-namespaces"
+       @fact-output => #".clj:24"))))

--- a/test/implementation/line_numbers/fim_tabular_parsing.clj
+++ b/test/implementation/line_numbers/fim_tabular_parsing.clj
@@ -1,6 +1,6 @@
 (ns implementation.line-numbers.fim-tabular-parsing
-  (:use midje.sweet
-        midje.test-util))
+  (:require [midje.sweet :refer :all]
+            [midje.test-util :refer :all]))
 
 ;; Check that errors are reported with the correct line numbers. There's one check for each
 ;; place where line numbers are reported.

--- a/test/implementation/parsing/1_to_explicit_form/fim_metadata.clj
+++ b/test/implementation/parsing/1_to_explicit_form/fim_metadata.clj
@@ -1,9 +1,9 @@
 (ns implementation.parsing.1-to-explicit-form.fim-metadata
-  (:use midje.sweet
-        midje.test-util
-        midje.parsing.1-to-explicit-form.metadata)
-  (:require [such.random :as random]
-            [midje.data.compendium :as compendium]))
+  (:require [midje.sweet :refer :all]
+            [midje.test-util :refer :all]
+            [midje.parsing.1-to-explicit-form.metadata :refer :all]
+            [midje.data.compendium :as compendium]
+            [such.random :as random]))
 
 (def a-body '((f) => 3))
 (def body-guid (random/form-hash a-body))

--- a/test/implementation/parsing/1_to_explicit_form/fim_parse_background.clj
+++ b/test/implementation/parsing/1_to_explicit_form/fim_parse_background.clj
@@ -1,15 +1,15 @@
 (ns implementation.parsing.1-to-explicit-form.fim-parse-background
-  (:use midje.sweet
-        midje.test-util
-        [midje.parsing.util.wrapping :only [for-wrapping-target?]]
-        [midje.parsing.2-to-lexical-maps.expects :only [expect]]
-        [midje.parsing.2-to-lexical-maps.fakes :only [fake]]
-        [midje.parsing.2-to-lexical-maps.data-fakes :only [data-fake]]
-        midje.util)
   (:require [clojure.zip :as zip]
-            [midje.util.unify :as unify]
+            [midje.sweet :refer :all]
+            [midje.parsing.1-to-explicit-form.parse-background :as parse-background]
+            [midje.parsing.2-to-lexical-maps.data-fakes :refer [data-fake]]
+            [midje.parsing.2-to-lexical-maps.expects :refer [expect]]
+            [midje.parsing.2-to-lexical-maps.fakes :refer [fake]]
             [midje.parsing.util.wrapping :as wrapping]
-            [midje.parsing.1-to-explicit-form.parse-background :as parse-background]))
+            [midje.parsing.util.wrapping :refer [for-wrapping-target?]]
+            [midje.test-util :refer :all]
+            [midje.util :refer :all]
+            [midje.util.unify :as unify]))
 (expose-testables midje.parsing.1-to-explicit-form.parse-background)
 
 

--- a/test/implementation/parsing/util/fim_exception_line_numbers.clj
+++ b/test/implementation/parsing/util/fim_exception_line_numbers.clj
@@ -1,5 +1,7 @@
 (ns implementation.parsing.util.fim_exception_line_numbers
-  (:use [midje sweet test-util]))
+  (:require [midje
+             [sweet :refer :all]
+             [test-util :refer :all]]))
 
 ;; These tests check line numbers, which have to be carefully copied into the
 ;; metadata of constructed forms.
@@ -8,17 +10,17 @@
  (macroexpand '(fact "description" (+ 1 1) =throw-parse-exception=> 2))
  (fact
    @fact-output => #"Midje caught an exception when translating this form"
-   @fact-output => #"fim_exception_line_numbers.clj:8"))
+   @fact-output => #"fim_exception_line_numbers.clj:10"))
    
 
 (capturing-failure-output ;; Reports on outer-level fact
  (macroexpand '(fact "fine" (fact "description" (+ 1 1) =throw-parse-exception=> 2)))
  (fact
    @fact-output => #"(?s)Midje caught an exception when translating this form.*fact.*fine"
-   @fact-output => #"fim_exception_line_numbers.clj:15"))
+   @fact-output => #"fim_exception_line_numbers.clj:17"))
 
 (capturing-failure-output
  (macroexpand '(tabular (fact (?a) =throw-parse-exception=> 1) ?a 2))
  (fact
    @fact-output => #"(?s)Midje caught an exception when translating this form.*tabular.*fact"
-   @fact-output => #"fim_exception_line_numbers.clj:21"))
+   @fact-output => #"fim_exception_line_numbers.clj:23"))

--- a/test/implementation/parsing/util/fim_overrides.clj
+++ b/test/implementation/parsing/util/fim_overrides.clj
@@ -1,7 +1,7 @@
 (ns implementation.parsing.util.fim_overrides
-  (:use midje.sweet
-        midje.test-util
-        midje.parsing.util.overrides))
+  (:require [midje.sweet :refer :all]
+            [midje.test-util :refer :all]
+            [midje.parsing.util.overrides :refer :all]))
 
 (fact "when at end of required part of arrow form, can ask for overrides"
     "empty rest of form"

--- a/test/implementation/parsing/util/fim_recognizing.clj
+++ b/test/implementation/parsing/util/fim_recognizing.clj
@@ -1,9 +1,9 @@
 (ns implementation.parsing.util.fim_recognizing
-  (:use midje.sweet
-        midje.test-util
-        [midje.parsing.2-to-lexical-maps.expects :only [expect]]
-        midje.parsing.util.recognizing)
-  (:require [clojure.zip :as zip]))
+  (:require [midje.sweet :refer :all]
+            [midje.test-util :refer :all]
+            [midje.parsing.2-to-lexical-maps.expects :refer [expect]]
+            [midje.parsing.util.recognizing :refer :all]
+            [clojure.zip :as zip]))
 
 ;;; Arrows 
 

--- a/test/implementation/prerequisites/fim_call_counts.clj
+++ b/test/implementation/prerequisites/fim_call_counts.clj
@@ -1,6 +1,8 @@
 (ns implementation.prerequisites.fim_call_counts
-  (:use [midje sweet test-util]
-        midje.checking.checkables))
+  (:require [midje
+             [sweet :refer :all]
+             [test-util :refer :all]]
+            [midje.checking.checkables :refer :all]))
 
 (tabular
   (fact "The expected call count can be described"

--- a/test/implementation/util/fim_exceptions.clj
+++ b/test/implementation/util/fim_exceptions.clj
@@ -1,7 +1,9 @@
 (ns implementation.util.fim-exceptions
-  (:use [midje.util.exceptions]
-	      [midje sweet test-util]
-        [midje.util]))
+  (:require [midje.util.exceptions :refer :all]
+            [midje
+             [sweet :refer :all]
+             [test-util :refer :all]]
+            [midje.util :refer :all]))
 
 (expose-testables midje.util.exceptions)
 

--- a/test/midje/checking/checkers/t_chatty.clj
+++ b/test/midje/checking/checkers/t_chatty.clj
@@ -1,12 +1,12 @@
 (ns midje.checking.checkers.t-chatty
-  (:use midje.sweet
-        midje.util
-        midje.checking.core
-        [midje.checking.checkers.defining :only [checker?]]
-        [midje.checking.checkers.chatty :only [chatty-worth-reporting-on?
-                                      chatty-untease
-                                      chatty-checker?]]
-        midje.test-util))
+  (:require [midje.sweet :refer :all]
+            [midje.util :refer :all]
+            [midje.checking.core :refer :all]
+            [midje.checking.checkers.defining :refer [checker?]]
+            [midje.checking.checkers.chatty :refer [chatty-worth-reporting-on?
+                                                    chatty-untease
+                                                    chatty-checker?]]
+            [midje.test-util :refer :all]))
 (expose-testables midje.checking.checkers.chatty)
 
 (facts "about chatty-checking utility functions"

--- a/test/midje/checking/checkers/t_collection.clj
+++ b/test/midje/checking/checkers/t_collection.clj
@@ -1,9 +1,9 @@
 (ns midje.checking.checkers.t-collection
-  (:use midje.sweet
-        midje.test-util
-        midje.checking.core
-        [midje.checking.checkers.defining :only [checker?]]
-        midje.util))
+  (:require [midje.sweet :refer :all]
+            [midje.test-util :refer :all]
+            [midje.checking.core :refer :all]
+            [midje.checking.checkers.defining :refer [checker?]]
+            [midje.util :refer :all]))
 (expose-testables midje.checking.checkers.collection)
 
 (defrecord AB [a b])

--- a/test/midje/checking/checkers/t_collection_old.clj
+++ b/test/midje/checking/checkers/t_collection_old.clj
@@ -1,7 +1,7 @@
 (ns midje.checking.checkers.t-collection-old
-  (:use midje.sweet
-        midje.checking.core
-        midje.test-util))
+  (:require [midje.sweet :refer :all]
+            [midje.checking.core :refer :all]
+            [midje.test-util :refer :all]))
 
 ;; These are still potentially useful tests from a misguided code organization.
 ;; Delete them as they fail (after moving better tests to t-collection.

--- a/test/midje/checking/checkers/t_combining.clj
+++ b/test/midje/checking/checkers/t_combining.clj
@@ -1,9 +1,9 @@
 (ns midje.checking.checkers.t-combining
-  (:use midje.sweet
-        commons.clojure.core
-        midje.checking.core
-        [midje.checking.checkers.defining :only [checker?]]
-        midje.test-util))
+  (:require [midje.sweet :refer :all]
+            [commons.clojure.core :refer :all]
+            [midje.checking.core :refer :all]
+            [midje.checking.checkers.defining :refer [checker?]]
+            [midje.test-util :refer :all]))
 
 (fact "about 'every' combinations"
   (let [checker (every-checker odd?

--- a/test/midje/checking/checkers/t_defining.clj
+++ b/test/midje/checking/checkers/t_defining.clj
@@ -1,7 +1,7 @@
 (ns midje.checking.checkers.t-defining
-  (:use midje.sweet
-        [midje.checking.checkers.defining :only [checker?]]
-        midje.test-util))
+  (:require [midje.sweet :refer :all]
+            [midje.checking.checkers.defining :refer [checker?]]
+            [midje.test-util :refer :all]))
 
 (defchecker magic-number "magic number docstring" {:meta-data :foo} [actual] (= 587 actual))
 (fact "checker with a doc string"

--- a/test/midje/checking/checkers/t_simple.clj
+++ b/test/midje/checking/checkers/t_simple.clj
@@ -1,7 +1,7 @@
 (ns midje.checking.checkers.t-simple
-  (:use midje.sweet
-        [midje.checking.checkers.defining :only [checker?]]
-        midje.test-util))
+  (:require [midje.sweet :refer :all]
+            [midje.checking.checkers.defining :refer [checker?]]
+            [midje.test-util :refer :all]))
 
 
 (facts "about truthy"

--- a/test/midje/checking/t_core.clj
+++ b/test/midje/checking/t_core.clj
@@ -1,7 +1,7 @@
 (ns midje.checking.t-core
-  (:use midje.sweet
-        midje.checking.core
-        midje.test-util))
+  (:require [midje.sweet :refer :all]
+            [midje.checking.core :refer :all]
+            [midje.test-util :refer :all]))
 
 (facts "about an extended notion of falsehood"
   (extended-false? false) => truthy

--- a/test/midje/data/t_compendium.clj
+++ b/test/midje/data/t_compendium.clj
@@ -1,8 +1,8 @@
 (ns midje.data.t-compendium
-  (:use [midje.sweet]
-        [midje.test-util]
-        [midje.data.compendium])
-  (:require [midje.util.ecosystem :as ecosystem]
+  (:require [midje.sweet :refer :all]
+            [midje.test-util :refer :all]
+            [midje.data.compendium :refer :all]
+            [midje.util.ecosystem :as ecosystem]
             [midje.config :as config]
             [midje.data.fact :as fact]
             [midje.checking.facts :as fact-checking]))

--- a/test/midje/data/t_metaconstant.clj
+++ b/test/midje/data/t_metaconstant.clj
@@ -1,7 +1,9 @@
 (ns midje.data.t-metaconstant
-  (:use midje.data.metaconstant
-        [midje sweet test-util])
-  (:require [clojure.zip :as zip])
+  (:require [midje.data.metaconstant :refer :all]
+            [midje
+             [sweet :refer :all]
+             [test-util :refer :all]]
+            [clojure.zip :as zip])
   (:import midje.data.metaconstant.Metaconstant))
 
 ;;; Metaconstant symbols

--- a/test/midje/data/t_nested_facts.clj
+++ b/test/midje/data/t_nested_facts.clj
@@ -1,9 +1,9 @@
 (ns midje.data.t-nested-facts
-  (:use [midje.data.nested-facts]
-        clojure.test
-        midje.sweet
-        midje.test-util)
-  (:require [midje.util.pile :as pile]))
+  (:require [midje.data.nested-facts :refer :all]
+            [clojure.test :refer :all]
+            [midje.sweet :refer :all]
+            [midje.test-util :refer :all]
+            [midje.util.pile :as pile]))
 
 
 (defn faux-fact

--- a/test/midje/data/t_prerequisite_state.clj
+++ b/test/midje/data/t_prerequisite_state.clj
@@ -1,13 +1,14 @@
 (ns midje.data.t-prerequisite-state
-  (:use commons.clojure.core
-        [midje sweet test-util]
-        [midje.data.prerequisite-state :except [mockable-funcall? unfolding-step merge-metaconstant-bindings 
-                                             unique-vars handle-mocked-call best-call-action ]]
-        [midje.test-util]
-        [midje.parsing.2-to-lexical-maps.fakes :only [fake]]
-        [midje.parsing.2-to-lexical-maps.data-fakes :only [data-fake]]
-        midje.util)
-  (:require [midje.config :as config]
+  (:require [commons.clojure.core :refer :all]
+            [midje
+             [sweet :refer :all]
+             [test-util :refer :all]]
+            [midje.data.prerequisite-state :refer [binding-map implements-a-fake? usable-default-function?]]
+            [midje.test-util :refer :all]
+            [midje.parsing.2-to-lexical-maps.fakes :refer [fake]]
+            [midje.parsing.2-to-lexical-maps.data-fakes :refer [data-fake]]
+            [midje.util :refer :all]
+            [midje.config :as config]
             [such.sequences :as seq])
   (:import midje.data.metaconstant.Metaconstant))
 

--- a/test/midje/data/t_project_state.clj
+++ b/test/midje/data/t_project_state.clj
@@ -1,10 +1,10 @@
 (ns midje.data.t-project-state
-  (:use [midje.sweet]
-        [midje.test-util]
-        [midje.data.project-state])
-  (:require [midje.util.ecosystem :as ecosystem]
-            [midje.util.bultitude :as tude])
-  (:require [clojure.java.io :as io]))
+  (:require [midje.sweet :refer :all]
+            [midje.test-util :refer :all]
+            [midje.data.project-state :refer :all]
+            [midje.util.ecosystem :as ecosystem]
+            [midje.util.bultitude :as tude]
+            [clojure.java.io :as io]))
 
 
 ;;; Directory structure

--- a/test/midje/emission/plugins/t_default.clj
+++ b/test/midje/emission/plugins/t_default.clj
@@ -1,6 +1,9 @@
 (ns midje.emission.plugins.t-default
-  (:use [midje sweet util test-util])
-  (:require [midje.emission.plugins.default :as plugin]
+  (:require [midje
+             [sweet :refer :all]
+             [util :refer :all]
+             [test-util :refer :all]]
+            [midje.emission.plugins.default :as plugin]
             [midje.emission.state :as state]
             [clojure.string :as str]))
 

--- a/test/midje/emission/plugins/t_default_end_to_end.clj
+++ b/test/midje/emission/plugins/t_default_end_to_end.clj
@@ -1,6 +1,8 @@
 (ns midje.emission.plugins.t-default-end-to-end
-  (:use [midje sweet test-util])
-  (:require [midje.config :as config]))
+  (:require [midje
+             [sweet :refer :all]
+             [test-util :refer :all]]
+            [midje.config :as config]))
 
 (capturing-failure-output
  (fact (+ 1 1) => 3)

--- a/test/midje/emission/plugins/t_default_failure_lines.clj
+++ b/test/midje/emission/plugins/t_default_failure_lines.clj
@@ -1,7 +1,10 @@
 (ns midje.emission.plugins.t-default-failure-lines
-  (:use [midje sweet util test-util]
-        midje.emission.plugins.default-failure-lines)
-  (:require [midje.emission.plugins.util :as util]))
+  (:require [midje
+             [sweet :refer :all]
+             [util :refer :all]
+             [test-util :refer :all]]
+            [midje.emission.plugins.default-failure-lines :refer :all]
+            [midje.emission.plugins.util :as util]))
 
 
 ;;; Note that this will scrozzle the failure notice from the facts below

--- a/test/midje/emission/plugins/t_junit.clj
+++ b/test/midje/emission/plugins/t_junit.clj
@@ -1,6 +1,9 @@
 (ns midje.emission.plugins.t-junit
-  (:use [midje sweet util test-util])
-  (:require [midje.emission.plugins.junit :as plugin]
+  (:require [midje
+             [sweet :refer :all]
+             [util :refer :all]
+             [test-util :refer :all]]
+            [midje.emission.plugins.junit :as plugin]
             [midje.config :as config]
             [midje.emission.plugins.default-failure-lines :as failure-lines]))
 

--- a/test/midje/emission/plugins/t_progress.clj
+++ b/test/midje/emission/plugins/t_progress.clj
@@ -1,6 +1,9 @@
 (ns midje.emission.plugins.t-progress
-  (:use [midje sweet util test-util])
-  (:require [midje.emission.plugins.progress :as plugin]
+  (:require [midje
+             [sweet :refer :all]
+             [util :refer :all]
+             [test-util :refer :all]]
+            [midje.emission.plugins.progress :as plugin]
             [midje.config :as config]
             [midje.emission.colorize :as color]
             [midje.emission.state :as state]))

--- a/test/midje/emission/plugins/t_tap.clj
+++ b/test/midje/emission/plugins/t_tap.clj
@@ -1,6 +1,9 @@
 (ns midje.emission.plugins.t-tap
-  (:use [midje sweet util test-util])
-  (:require [midje.emission.plugins.tap :as tap]
+  (:require [midje
+             [sweet :refer :all]
+             [util :refer :all]
+             [test-util :refer :all]]
+            [midje.emission.plugins.tap :as tap]
             [midje.config :as config]
             [midje.emission.plugins.default-failure-lines :as failure-lines]
             [midje.emission.plugins.util :as util]))

--- a/test/midje/emission/plugins/t_util.clj
+++ b/test/midje/emission/plugins/t_util.clj
@@ -1,8 +1,7 @@
 (ns midje.emission.plugins.t-util
-  (:require
-   [midje.config :as config])
-  (:use midje.sweet
-        midje.emission.plugins.util))
+  (:require [midje.config :as config]
+            [midje.sweet :refer :all]
+            [midje.emission.plugins.util :refer :all]))
 
 (fact "line structures can be linearized"
   (linearize-lines [ ["1" [nil] "2" nil] [] "3" [[["4"]]]]) => ["1" "2" "3" "4"])

--- a/test/midje/emission/t_api.clj
+++ b/test/midje/emission/t_api.clj
@@ -1,7 +1,7 @@
 (ns midje.emission.t-api
-  (:use midje.sweet
-        midje.test-util)
-  (:require [midje.emission.api :as emit]
+  (:require [midje.sweet :refer :all]
+            [midje.test-util :refer :all]
+            [midje.emission.api :as emit]
             [midje.emission.levels :as levels]
             [midje.emission.state :as state]
             [midje.emission.plugins.test-support :as plugin]

--- a/test/midje/emission/t_boundaries.clj
+++ b/test/midje/emission/t_boundaries.clj
@@ -1,7 +1,10 @@
 (ns midje.emission.t-boundaries
-  (:use midje.emission.boundaries
-        [midje sweet util test-util])
-  (:require [midje.emission.clojure-test-facade :as ctf]
+  (:require [midje.emission.boundaries :refer :all]
+            [midje
+             [sweet :refer :all]
+             [util :refer :all]
+             [test-util :refer :all]]
+            [midje.emission.clojure-test-facade :as ctf]
             [midje.emission.state :as state]))
 
 (facts "about two forms of results"

--- a/test/midje/emission/t_clojure_test_facade.clj
+++ b/test/midje/emission/t_clojure_test_facade.clj
@@ -1,8 +1,8 @@
 (ns midje.emission.t-clojure-test-facade
-  (:use midje.sweet
-        midje.emission.clojure-test-facade
-        midje.test-util)
-  (:require clojure.test))
+  (:require [midje.sweet :refer :all]
+            [midje.emission.clojure-test-facade :refer :all]
+            [midje.test-util :refer :all]
+            clojure.test))
 
 ;;; run-tests
 

--- a/test/midje/emission/t_colorize.clj
+++ b/test/midje/emission/t_colorize.clj
@@ -1,7 +1,7 @@
 (ns midje.emission.t-colorize
-  (:use midje.sweet
-        [midje.util.ecosystem :only [getenv on-windows?]])
-  (:require [midje.emission.colorize :as color]
+  (:require [midje.sweet :refer :all]
+            [midje.util.ecosystem :refer [getenv on-windows?]]
+            [midje.emission.colorize :as color]
             [midje.config :as config]))
 
 (tabular

--- a/test/midje/emission/t_deprecation.clj
+++ b/test/midje/emission/t_deprecation.clj
@@ -1,7 +1,9 @@
 (ns midje.emission.t-deprecation
-  (:use midje.emission.deprecation)
-  (:use [midje sweet test-util])
-  (:require [midje.config :as config]
+  (:require [midje.emission.deprecation :refer :all]
+            [midje
+             [sweet :refer :all]
+             [test-util :refer :all]]
+            [midje.config :as config]
             [midje.util.ecosystem :as ecosystem]))
 
 

--- a/test/midje/emission/t_levels.clj
+++ b/test/midje/emission/t_levels.clj
@@ -1,7 +1,10 @@
 (ns midje.emission.t-levels
-  (:use midje.emission.levels
-        [midje sweet util test-util])
-  (:require [midje.config :as config]))
+  (:require [midje.emission.levels :refer :all]
+            [midje
+             [sweet :refer :all]
+             [util :refer :all]
+             [test-util :refer :all]]
+            [midje.config :as config]))
 
 (facts "about levels"
   (-> -2 levels-to-names names-to-levels) => -2

--- a/test/midje/parsing/0_to_fact_form/t_internal_against_background.clj
+++ b/test/midje/parsing/0_to_fact_form/t_internal_against_background.clj
@@ -1,7 +1,7 @@
 (ns ^{:doc "A fact's internal against-background ends up wrapping it"}
   midje.parsing.0-to-fact-form.t-internal-against-background
-  (:use midje.sweet)
-  (:require [midje.config :as config]
+  (:require [midje.sweet :refer :all]
+            [midje.config :as config]
             [midje.data.compendium :as compendium]
             [midje.data.fact :as fact]))
 

--- a/test/midje/parsing/0_to_fact_form/t_tabular.clj
+++ b/test/midje/parsing/0_to_fact_form/t_tabular.clj
@@ -1,10 +1,12 @@
 (ns midje.parsing.0-to-fact-form.t-tabular
-  (:use [midje.parsing.0-to-fact-form.tabular :except [table-binding-maps]]
-        [midje.data.metaconstant :only [metaconstant-symbol?]]
-        [midje sweet test-util]
-        [midje.util.ordered-map :only (ordered-map)]
-        midje.util)
-  (:require [such.random :as random]
+  (:require midje.parsing.0-to-fact-form.tabular
+            [midje.data.metaconstant :refer [metaconstant-symbol?]]
+            [midje
+             [sweet :refer :all]
+             [test-util :refer :all]]
+            [midje.util.ordered-map :refer [ordered-map]]
+            [midje.util :refer :all]
+            [such.random :as random]
             [midje.parsing.lexical-maps :as maps]
             [midje.parsing.1-to-explicit-form.facts :as parse-facts]
             [midje.data.fact :as fact-data]

--- a/test/midje/parsing/1_to_explicit_form/t_expects.clj
+++ b/test/midje/parsing/1_to_explicit_form/t_expects.clj
@@ -1,9 +1,9 @@
 (ns midje.parsing.1-to-explicit-form.t-expects
-  (:use midje.sweet
-        midje.test-util
-        [midje.parsing.2-to-lexical-maps.expects :only [expect]]
-        midje.parsing.1-to-explicit-form.expects)
-  (:require [clojure.zip :as zip]
+  (:require [midje.sweet :refer :all]
+            [midje.test-util :refer :all]
+            [midje.parsing.2-to-lexical-maps.expects :refer [expect]]
+            [midje.parsing.1-to-explicit-form.expects :refer :all]
+            [clojure.zip :as zip]
             [midje.parsing.util.recognizing :as recognize]))
 
 (fact "can position so loc is the entire expect form"

--- a/test/midje/parsing/1_to_explicit_form/t_facts.clj
+++ b/test/midje/parsing/1_to_explicit_form/t_facts.clj
@@ -1,12 +1,12 @@
 (ns midje.parsing.1-to-explicit-form.t-facts
-  (:use midje.parsing.1-to-explicit-form.facts
-        midje.sweet
-        midje.test-util
-        [midje.parsing.2-to-lexical-maps.expects :only [expect]]
-        [midje.parsing.2-to-lexical-maps.fakes :only [fake]]
-        [midje.parsing.2-to-lexical-maps.data-fakes :only [data-fake]]
-        [pointer.core :only [line-number-known]])
-  (:require [clojure.zip :as zip]
+  (:require [midje.parsing.1-to-explicit-form.facts :refer :all]
+            [midje.sweet :refer :all]
+            [midje.test-util :refer :all]
+            [midje.parsing.2-to-lexical-maps.expects :refer [expect]]
+            [midje.parsing.2-to-lexical-maps.fakes :refer [fake]]
+            [midje.parsing.2-to-lexical-maps.data-fakes :refer [data-fake]]
+            [pointer.core :refer [line-number-known]]
+            [clojure.zip :as zip]
             [midje.config :as config]))
 
 

--- a/test/midje/parsing/1_to_explicit_form/t_metaconstants.clj
+++ b/test/midje/parsing/1_to_explicit_form/t_metaconstants.clj
@@ -1,6 +1,8 @@
 (ns midje.parsing.1-to-explicit-form.t-metaconstants
-  (:use midje.parsing.1-to-explicit-form.metaconstants
-        [midje sweet test-util])
+  (:require [midje.parsing.1-to-explicit-form.metaconstants :refer :all]
+            [midje
+             [sweet :refer :all]
+             [test-util :refer :all]])
   (:import midje.data.metaconstant.Metaconstant))
 
 ;;; Two different ways of creating metaconstants from user forms

--- a/test/midje/parsing/1_to_explicit_form/t_prerequisites.clj
+++ b/test/midje/parsing/1_to_explicit_form/t_prerequisites.clj
@@ -1,9 +1,10 @@
 (ns midje.parsing.1-to-explicit-form.t-prerequisites
-  (:use midje.parsing.1-to-explicit-form.prerequisites
-        midje.sweet midje.test-util
-        [midje.parsing.2-to-lexical-maps.fakes :only [fake]]
-        [midje.parsing.2-to-lexical-maps.data-fakes :only [data-fake]])
-  (:require [clojure.zip :as zip]
+  (:require [midje.parsing.1-to-explicit-form.prerequisites :refer :all]
+            [midje.sweet :refer :all]
+            [midje.test-util :refer :all]
+            [midje.parsing.2-to-lexical-maps.fakes :refer [fake]]
+            [midje.parsing.2-to-lexical-maps.data-fakes :refer [data-fake]]
+            [clojure.zip :as zip]
             [midje.parsing.util.recognizing :as recognize]))
 
 (fact "can convert prerequisites into fake calls"

--- a/test/midje/parsing/2_to_lexical_maps/t_data_fakes.clj
+++ b/test/midje/parsing/2_to_lexical_maps/t_data_fakes.clj
@@ -1,12 +1,14 @@
 (ns midje.parsing.2-to-lexical-maps.t-data-fakes
-  (:use [midje sweet test-util]
-        midje.parsing.2-to-lexical-maps.data-fakes
-        midje.util))
+  (:require [midje
+             [sweet :refer :all]
+             [test-util :refer :all]]
+            [midje.parsing.2-to-lexical-maps.data-fakes :refer :all]
+            [midje.util :refer :all]))
 
 (silent-fact "check line number and file position of errors"
   (f) => 0
   (provided  ;; since no form on left-hand-side, this is the line number used.
     mistake =contains=> {:a 0}))
 (note-that (failure-was-in-file "t_data_fakes.clj")
-           (failure-was-at-line 8))
+           (failure-was-at-line 10))
 

--- a/test/midje/parsing/2_to_lexical_maps/t_expects.clj
+++ b/test/midje/parsing/2_to_lexical_maps/t_expects.clj
@@ -1,13 +1,13 @@
 (ns midje.parsing.2-to-lexical-maps.t-expects
-  (:use clojure.test  ;; This is used to check production mode with deftest.
-        commons.clojure.core
-        midje.sweet
-        midje.parsing.2-to-lexical-maps.expects
-        [midje.parsing.2-to-lexical-maps.fakes :only [fake]]
-        [midje.parsing.2-to-lexical-maps.data-fakes :only [data-fake]]
-        midje.test-util
-        midje.util)
-  (:require [such.sequences :as seq]
+  (:require [clojure.test :refer :all]  ;; This is used to check production mode with deftest.
+            [commons.clojure.core :refer :all]
+            [midje.sweet :refer :all]
+            [midje.parsing.2-to-lexical-maps.expects :refer :all]
+            [midje.parsing.2-to-lexical-maps.fakes :refer [fake]]
+            [midje.parsing.2-to-lexical-maps.data-fakes :refer [data-fake]]
+            [midje.test-util :refer :all]
+            [midje.util :refer :all]
+            [such.sequences :as seq]
             [midje.config :as config]
             [midje.util.pile :as pile]
             [midje.parsing.util.recognizing :as recognize]

--- a/test/midje/parsing/2_to_lexical_maps/t_fakes.clj
+++ b/test/midje/parsing/2_to_lexical_maps/t_fakes.clj
@@ -1,12 +1,14 @@
 (ns midje.parsing.2-to-lexical-maps.t-fakes
-  (:use [midje sweet test-util]
-        midje.parsing.2-to-lexical-maps.fakes
-        midje.util))
+  (:require [midje
+             [sweet :refer :all]
+             [test-util :refer :all]]
+            [midje.parsing.2-to-lexical-maps.fakes :refer :all]
+            [midje.util :refer :all]))
 
 (silent-fact "check line number and file position of t_fakes errors"
   (f) => 0
   (provided
     (deref cons) => 0))  ; for example
 (note-that (failure-was-in-file "t_fakes.clj")
-           (failure-was-at-line 9))
+           (failure-was-at-line 11))
 

--- a/test/midje/parsing/2_to_lexical_maps/t_folded_fakes.clj
+++ b/test/midje/parsing/2_to_lexical_maps/t_folded_fakes.clj
@@ -1,9 +1,10 @@
 (ns midje.parsing.2-to-lexical-maps.t-folded-fakes
-  (:use [midje sweet test-util]
-        [midje.parsing.2-to-lexical-maps.fakes :only [fake]]
-        midje.parsing.2-to-lexical-maps.folded-fakes
-        midje.util)
-  (:require [midje.util :as util]))
+  (:use midje.parsing.2-to-lexical-maps.folded-fakes)
+  (:require [midje
+             [sweet :refer :all]
+             [test-util :refer :all]]
+            [midje.parsing.2-to-lexical-maps.fakes :refer [fake]]
+            [midje.util :refer :all :as util]))
 
 (util/expose-testables midje.parsing.2-to-lexical-maps.folded-fakes)
 

--- a/test/midje/parsing/3_from_lexical_maps/t_from_fake_maps.clj
+++ b/test/midje/parsing/3_from_lexical_maps/t_from_fake_maps.clj
@@ -1,9 +1,11 @@
 (ns midje.parsing.3-from-lexical-maps.t-from-fake-maps
-  (:use [midje sweet test-util]
-        [midje.parsing.3-from-lexical-maps.from-fake-maps]
-        [midje.test-util]
-        midje.util)
-  (:require [midje.config :as config])
+  (:require [midje
+             [sweet :refer :all]
+             [test-util :refer :all]]
+            [midje.parsing.3-from-lexical-maps.from-fake-maps :refer :all]
+            [midje.test-util :refer :all]
+            [midje.util :refer :all]
+            [midje.config :as config])
   (:import midje.data.metaconstant.Metaconstant))
 
 (expose-testables midje.data.prerequisite-state)

--- a/test/midje/parsing/other/t_arglists.clj
+++ b/test/midje/parsing/other/t_arglists.clj
@@ -1,8 +1,8 @@
 (ns midje.parsing.other.t-arglists
-  (:use midje.sweet
-        midje.test-util
-        midje.parsing.other.arglists)
-  (:require [midje.emission.levels :as print-levels]))
+  (:require [midje.sweet :refer :all]
+            [midje.test-util :refer :all]
+            [midje.parsing.other.arglists :refer :all]
+            [midje.emission.levels :as print-levels]))
 
 (facts "separating levels out of argument lists"
   (separate-print-levels [] :print-normally)

--- a/test/midje/parsing/util/t_core.clj
+++ b/test/midje/parsing/util/t_core.clj
@@ -1,11 +1,11 @@
 (ns midje.parsing.util.t-core
-  (:use midje.parsing.util.core
-        midje.sweet
-        [midje.parsing.2-to-lexical-maps.expects :only [expect]]
-        [midje.parsing.2-to-lexical-maps.fakes :only [fake]]
-        [midje.parsing.2-to-lexical-maps.data-fakes :only [data-fake]]
-        midje.test-util)
-  (:require [clojure.zip :as zip]))
+  (:require [midje.parsing.util.core :refer :all]
+            [midje.sweet :refer :all]
+            [midje.parsing.2-to-lexical-maps.expects :refer [expect]]
+            [midje.parsing.2-to-lexical-maps.fakes :refer [fake]]
+            [midje.parsing.2-to-lexical-maps.data-fakes :refer [data-fake]]
+            [midje.test-util :refer :all]
+            [clojure.zip :as zip]))
 
 (facts "a form's reader-assigned line-number can be extracted"
   (reader-line-number (with-meta '(fact (this that)) {:line 23})) => 23

--- a/test/midje/parsing/util/t_zip.clj
+++ b/test/midje/parsing/util/t_zip.clj
@@ -1,9 +1,8 @@
 (ns midje.parsing.util.t-zip
-  (:use [midje.parsing.util.zip]
-	midje.sweet
-	midje.test-util)
-  (:require [clojure.zip :as zip])
-)
+  (:require [midje.parsing.util.zip :refer :all]
+            [midje.sweet :refer :all]
+            [midje.test-util :refer :all]
+            [clojure.zip :as zip]))
 
 (defn node [expected] (fn [actual] (= expected (zip/node actual))))
 

--- a/test/midje/t_repl.clj
+++ b/test/midje/t_repl.clj
@@ -1,7 +1,7 @@
 (ns midje.t-repl
-  (:use midje.repl
-        [midje.test-util])
-  (:require [midje.config :as config]
+  (:require [midje.repl :refer :all]
+            [midje.test-util :refer :all]
+            [midje.config :as config]
             [midje.emission.state :as state]
             [midje.data.compendium :as compendium]
             [midje.data.project-state :as project-state]

--- a/test/midje/t_repl_helper.clj
+++ b/test/midje/t_repl_helper.clj
@@ -1,6 +1,6 @@
 (ns midje.t-repl-helper
-  (:use midje.sweet
-        [midje.test-util]))
+  (:require [midje.sweet :refer :all]
+            [midje.test-util :refer :all]))
 
 (fact "a simple test"
   (+ 1 2) => 3)

--- a/test/midje/t_sweet.clj
+++ b/test/midje/t_sweet.clj
@@ -1,17 +1,17 @@
 (ns midje.t-sweet
-  (:use midje.sweet
-        midje.util
-        midje.test-util)
-  (:require [midje.repl :as repl]
+  (:require [midje.sweet :refer :all]
+            [midje.util :refer :all]
+            [midje.test-util :refer :all]
+            [midje.repl :as repl]
             [midje.config :as config]
             [midje.util.ecosystem :as ecosystem]
             [midje.emission.clojure-test-facade :as ctf]
             [midje.emission.api :as emit]
             [midje.emission.state :as state]
-            [midje.data.compendium :as compendium])
-  ;; Following is for testing the use of vars to fake private functions
-  ;; in another namespace.
-  (:require midje.data.t-prerequisite-state))
+            [midje.data.compendium :as compendium]
+            ;; Following is for testing the use of vars to fake private functions
+            ;; in another namespace.
+            midje.data.t-prerequisite-state))
 
 (fact "all of Midje's public, API-facing vars have docstrings"
   ;; At the moment, use of Potemkin to import vars breaks the following tests.

--- a/test/midje/test_util.clj
+++ b/test/midje/test_util.clj
@@ -1,9 +1,9 @@
 (ns midje.test-util
-  (:use [clojure.test]
-        midje.checkers
-        midje.checking.core
-        midje.util.exceptions)
-  (:require [midje.config :as config]
+  (:require [clojure.test :refer :all]
+            [midje.checkers :refer :all]
+            [midje.checking.core :refer :all]
+            [midje.util.exceptions :refer :all]
+            [midje.config :as config]
             [clojure.string :as str]
             [midje.emission.api :as emit]
             [midje.parsing.expanded-symbols :as expanded-symbols]

--- a/test/midje/util/t_ecosystem.clj
+++ b/test/midje/util/t_ecosystem.clj
@@ -1,7 +1,7 @@
 (ns midje.util.t-ecosystem
-  (:use midje.sweet
-        midje.util.ecosystem
-        midje.test-util))
+  (:require [midje.sweet :refer :all]
+            [midje.util.ecosystem :refer :all]
+            [midje.test-util :refer :all]))
 
 (fact "can find paths to load from project.clj"
   (against-background (around :facts (around-initial-paths ?form)))

--- a/test/midje/util/t_laziness.clj
+++ b/test/midje/util/t_laziness.clj
@@ -1,7 +1,9 @@
 (ns midje.util.t-laziness
-  (:use [midje.sweet]
-        [midje.util laziness thread-safe-var-nesting]
-        [midje.test-util]))
+  (:require [midje.sweet :refer :all]
+            [midje.util
+             [laziness :refer :all]
+             [thread-safe-var-nesting :refer :all]]
+            [midje.test-util :refer :all]))
 
 ;; Justification for use of eagerly
 (def counter (atom :needs-to-be-initialized))

--- a/test/midje/util/t_one_seven.clj
+++ b/test/midje/util/t_one_seven.clj
@@ -1,7 +1,9 @@
 (ns midje.util.t-one-seven
-  (:use [midje.sweet]
-        [midje.util laziness thread-safe-var-nesting]
-        [midje.test-util]))
+  (:require [midje.sweet :refer :all]
+            [midje.util
+             [laziness :refer :all]
+             [thread-safe-var-nesting :refer :all]]
+            [midje.test-util :refer :all]))
 
 ;; Justification for use of eagerly
 (def counter (atom :needs-to-be-initialized))

--- a/test/midje/util/t_pile.clj
+++ b/test/midje/util/t_pile.clj
@@ -1,7 +1,7 @@
 (ns midje.util.t-pile
-  (:use [midje.sweet])
-  (:use [midje.test-util])
-  (:require [midje.util.pile :as subject]))
+  (:require [midje.sweet :refer :all]
+            [midje.test-util :refer :all]
+            [midje.util.pile :as subject]))
 
 (fact "apply each function to each corresponding arg" 
   (subject/apply-pairwise [inc dec] [1 1] [2 2]) => [[2 0] [3 1]])

--- a/test/midje/util/t_thread_safe_var_nesting.clj
+++ b/test/midje/util/t_thread_safe_var_nesting.clj
@@ -1,9 +1,8 @@
 (ns midje.util.t-thread-safe-var-nesting
-  (:use [midje.util.thread-safe-var-nesting])
-  (:use midje.sweet)
-  (:require [clojure.zip :as zip])
-  (:use midje.test-util)
-)
+  (:require [midje.util.thread-safe-var-nesting :refer :all]
+            [midje.sweet :refer :all]
+            [clojure.zip :as zip]
+            [midje.test-util :refer :all]))
 
 (def root "root")
 (def unbound!)

--- a/test/midje/util/t_unify.clj
+++ b/test/midje/util/t_unify.clj
@@ -1,7 +1,7 @@
 (ns midje.util.t-unify
-  (:use midje.util.unify
-        midje.sweet
-        midje.test-util))
+  (:require [midje.util.unify :refer :all]
+            [midje.sweet :refer :all]
+            [midje.test-util :refer :all]))
 
 (fact "unify works with nil bindings"
   (substitute '(?without-binding (?nil-binding (?other-binding)))

--- a/test/user/fus_background.clj
+++ b/test/user/fus_background.clj
@@ -1,6 +1,6 @@
 (ns user.fus-background
-  (:use midje.sweet
-        midje.test-util))
+  (:require [midje.sweet :refer :all]
+            [midje.test-util :refer :all]))
 
 (unfinished g)
 

--- a/test/user/fus_check_after_creation.clj
+++ b/test/user/fus_check_after_creation.clj
@@ -1,7 +1,7 @@
 (ns user.fus-check-after-creation
-  (:use midje.repl
-        midje.test-util)
-  (:require [midje.config :as config]))
+  (:require [midje.repl :refer :all]
+            [midje.test-util :refer :all]
+            [midje.config :as config]))
 
 ;;; The following forms obey :check-after-creation
 

--- a/test/user/fus_checkers.clj
+++ b/test/user/fus_checkers.clj
@@ -1,6 +1,6 @@
 (ns user.fus-checkers
-  (:use midje.sweet
-        midje.test-util))
+  (:require [midje.sweet :refer :all]
+            [midje.test-util :refer :all]))
 
 (fact "simple checkers are exported into midje.sweet"
   1 => truthy

--- a/test/user/fus_config.clj
+++ b/test/user/fus_config.clj
@@ -1,6 +1,9 @@
 (ns user.fus-config
-  (:use [midje sweet util test-util])
-  (:require [midje.config :as config]))
+  (:require [midje
+             [sweet :refer :all]
+             [util :refer :all]
+             [test-util :refer :all]]
+            [midje.config :as config]))
 
 (fact "change-defaults operates on the root binding"
   (let [stashed-config config/*config*

--- a/test/user/fus_fact_metadata_and_quoting.clj
+++ b/test/user/fus_fact_metadata_and_quoting.clj
@@ -1,8 +1,8 @@
 (ns user.fus-fact-metadata-and-quoting
-  (:use midje.sweet
-        midje.test-util
-        midje.parsing.1-to-explicit-form.metadata)
-  (:require [midje.util.pile :as pile]
+  (:require [midje.sweet :refer :all]
+            [midje.test-util :refer :all]
+            [midje.parsing.1-to-explicit-form.metadata :refer :all]
+            [midje.util.pile :as pile]
             [midje.data.compendium :as compendium]))
 
 

--- a/test/user/fus_facts.clj
+++ b/test/user/fus_facts.clj
@@ -1,7 +1,7 @@
 (ns user.fus-facts
-  (:use midje.sweet
-        midje.test-util)
-  (:require [midje.config :as config]))
+  (:require [midje.sweet :refer :all]
+            [midje.test-util :refer :all]
+            [midje.config :as config]))
         
 
 (config/with-augmented-config {:visible-future true}

--- a/test/user/fus_midje_forms_in_macros.clj
+++ b/test/user/fus_midje_forms_in_macros.clj
@@ -1,6 +1,6 @@
 (ns user.fus-midje-forms-in-macros
-  (:use midje.sweet
-        midje.test-util))
+  (:require [midje.sweet :refer :all]
+            [midje.test-util :refer :all]))
 
 ;; Because of the way that Midje does its parsing, there are
 ;; complications when a user writes macros that wrap Midje forms. This

--- a/test/user/fus_nested_backgrounds.clj
+++ b/test/user/fus_nested_backgrounds.clj
@@ -1,6 +1,6 @@
 (ns user.fus-nested-backgrounds
-  (:use midje.sweet
-        midje.test-util))
+  (:require [midje.sweet :refer :all]
+            [midje.test-util :refer :all]))
 
 ;; It's proven tricky to get the nesting of the macroexpansion of backgrounds correct. Hence these tests.
 

--- a/test/user/fus_parse_errors.clj
+++ b/test/user/fus_parse_errors.clj
@@ -1,6 +1,6 @@
 (ns user.fus-parse-errors
-  (:use midje.sweet
-        midje.test-util))
+  (:require [midje.sweet :refer :all]
+            [midje.test-util :refer :all]))
 
 (unfinished f)
 (defn g [n] (f n))

--- a/test/user/fus_parse_exceptions.clj
+++ b/test/user/fus_parse_exceptions.clj
@@ -1,6 +1,6 @@
 (ns user.fus-parse-exceptions
-  (:use midje.sweet
-        midje.test-util))
+  (:require [midje.sweet :refer :all]
+            [midje.test-util :refer :all]))
 
 
 ;;; In general, it would be nice if these could be moved over to t-parse-errors.

--- a/test/user/fus_prerequisites__fact_wide.clj
+++ b/test/user/fus_prerequisites__fact_wide.clj
@@ -1,5 +1,5 @@
 (ns user.fus-prerequisites--fact-wide
-  (:use midje.sweet))
+  (:require [midje.sweet :refer :all]))
 
 ;; This was bug #161
 

--- a/test/user/fus_prerequisites__missing.clj
+++ b/test/user/fus_prerequisites__missing.clj
@@ -1,7 +1,7 @@
 (ns user.fus-prerequisites--missing
   "From https://github.com/marick/Midje/issues/332"
-  (:use midje.sweet
-        midje.test-util))
+  (:require [midje.sweet :refer :all]
+            [midje.test-util :refer :all]))
 
 (unfinished pre-process)
 (unfinished process)

--- a/test/user/fus_protocols/fus_protocols.clj
+++ b/test/user/fus_protocols/fus_protocols.clj
@@ -1,9 +1,10 @@
 (ns user.fus-protocols.fus-protocols
-  (:use [midje sweet test-util]
-        [midje.open-protocols]
-        midje.util.ecosystem
-        user.fus-protocols.protocols-defined-in-another-namespace)
-  (:require user.fus-protocols.protocols-defined-in-another-namespace))
+  (:require [midje
+             [sweet :refer :all]
+             [test-util :refer :all]]
+            [midje.open-protocols :refer :all]
+            [midje.util.ecosystem :refer :all]
+            [user.fus-protocols.protocols-defined-in-another-namespace :refer :all]))
 (import 'user.fus_protocols.protocols_defined_in_another_namespace.OutsideNSFakeableRecord)
 
 (fact "Imported record functions can be faked when called from outside"

--- a/test/user/fus_protocols/protocols_defined_in_another_namespace.clj
+++ b/test/user/fus_protocols/protocols_defined_in_another_namespace.clj
@@ -1,5 +1,5 @@
 (ns user.fus-protocols.protocols-defined-in-another-namespace
-  (:use midje.open-protocols))
+  (:require [midje.open-protocols :refer :all]))
 
 (defprotocol RecordFakeable
   (fake-me [this function])

--- a/test/user/fus_shape_checking.clj
+++ b/test/user/fus_shape_checking.clj
@@ -1,7 +1,7 @@
 (ns user.fus-shape-checking
-  (:use midje.sweet
-        midje.test-util)
-  (:require [midje.shape-checkers :as c]
+  (:require [midje.sweet :refer :all]
+            [midje.test-util :refer :all]
+            [midje.shape-checkers :as c]
             [midje.util.ecosystem :refer [when-1-7+]]))
 
 (when-1-7+

--- a/test/user/fus_tabular.clj
+++ b/test/user/fus_tabular.clj
@@ -1,6 +1,6 @@
 (ns user.fus-tabular
-  (:use midje.sweet
-        midje.test-util))
+  (:require [midje.sweet :refer :all]
+            [midje.test-util :refer :all]))
 
 ;;; Some pathological nesting cases
 

--- a/test/user/fus_threading.clj
+++ b/test/user/fus_threading.clj
@@ -1,7 +1,7 @@
 (ns user.fus-threading
-  (:use midje.sweet
-        midje.test-util
-        midje.util.ecosystem))
+  (:require [midje.sweet :refer :all]
+            [midje.test-util :refer :all]
+            [midje.util.ecosystem :refer :all]))
 
 (require '[plumbing.core :as plumbing])
 (require '[plumbing.graph :as graph])

--- a/test/user/fus_within_fact_backgrounds.clj
+++ b/test/user/fus_within_fact_backgrounds.clj
@@ -1,7 +1,7 @@
 (ns user.fus-within-fact-backgrounds
-  (:use midje.sweet
-        midje.test-util)
-  (:require [midje.data.fact :as fact-data]
+  (:require [midje.sweet :refer :all]
+            [midje.test-util :refer :all]
+            [midje.data.fact :as fact-data]
             [midje.data.compendium :as compendium]
             [such.random :as random]))
 


### PR DESCRIPTION
This replaces all `:use`s in namespace forms with `:require`, except for one that doesn't work when I do it (has to do with exposing a private macro after requiring it).

Why?  `use` is marked as deprecated, and I'm running Avi in [Jaunt]–a Clojure fork which reports deprecation warnings, among other things.

There are still three deprecation warnings from `ecosystem.clj` about the use of `*clojure-version*`, even though it doesn't seem to actually be marked deprecated.  That's a weird thing, dunno.

[Jaunt]: https://github.com/jaunt-lang/jaunt