### PR TITLE
Retain fact code in files even when not checking on load

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -20,8 +20,6 @@
   :profiles {:dev {:dependencies [[prismatic/plumbing "0.5.3"]]
                    :plugins [[lein-midje "3.1.4-SNAPSHOT"]]}
              :test-libs {:dependencies [[prismatic/plumbing "0.5.3"]]}
-             :1.5.0 [:test-libs {:dependencies [[org.clojure/clojure "1.5.0"]]}]
-             :1.5.1 [:test-libs {:dependencies [[org.clojure/clojure "1.5.1"]]}]
              :1.6 [:test-libs {:dependencies [[org.clojure/clojure "1.6.0"]]}]
              :1.7 [:test-libs {:dependencies [[org.clojure/clojure "1.7.0"]]}]
              :1.8 [:test-libs {:dependencies [[org.clojure/clojure "1.8.0"]]}]
@@ -38,8 +36,8 @@
   :deploy-repositories [["releases" :clojars]
                         ["snapshots" :clojars]]
 
-  :aliases {"compatibility" ["with-profile" "1.5.0:1.5.1:1.6:1.7:1.8" "midje" ":config" ".compatibility-test-config"]
-            "travis" ["with-profile" "1.5.0:1.5.1:1.6:1.7:1.8" "midje"]}
+  :aliases {"compatibility" ["with-profile" "1.6:1.7:1.8" "midje" ":config" ".compatibility-test-config"]
+            "travis" ["with-profile" "1.6:1.7:1.8" "midje"]}
 
   ;; For Clojure snapshots
   :repositories {"sonatype-oss-public" "https://oss.sonatype.org/content/groups/public/"


### PR DESCRIPTION
When running something like eastwood to lint test files, it's nice to be
able to not also run tests while linting.  Unfortunately setting
include-midje-checks to false means the test code that's meant to be
linted macro-expands to nil, so this patch puts the expanded code into a
defn where it won't be run but can still be linted.