### PR TITLE
When present, show the stacktrace of the underlying exception 'cause'

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject midje "1.9.0-alpha6"
+(defproject midje "1.9.0-alpha7"
   :description "A TDD library for Clojure that supports top-down ('mockish') TDD, encourages readable tests, provides a smooth migration path from clojure.test, balances abstraction and concreteness, and strives for graciousness."
   :url "https://github.com/marick/Midje"
   :pedantic? :warn

--- a/src/midje/util/exceptions.clj
+++ b/src/midje/util/exceptions.clj
@@ -35,6 +35,12 @@
   (cons (str throwable)
     (without-clojure-strings (stacktrace-as-strings throwable))))
 
+(defn- friendly-caused-by [ex prefix]
+  (when-let [cause (.getCause ex)]
+    (let [[data & stacktrace] (friendly-exception-lines cause prefix)]
+      (cons (str line-separator prefix "Caused by: " data)
+            stacktrace))))
+
 
 ;; When a fact throws an Exception or Error it gets wrapped
 ;; in this deftype
@@ -47,7 +53,9 @@
   ICapturedThrowable 
   (throwable [this] ex)
   (friendly-stacktrace [this]
-    (join line-separator (friendly-exception-lines (throwable this) "              "))))
+      (join line-separator
+            (concat (friendly-exception-lines (throwable this) "              ")
+                    (friendly-caused-by (throwable this) "              ")))))
 
 (defn captured-throwable [ex] 
   (CapturedThrowable. ex))

--- a/test/implementation/util/fim_exceptions.clj
+++ b/test/implementation/util/fim_exceptions.clj
@@ -48,7 +48,7 @@
   (let [lines (friendly-exception-lines (Error. "message") ">>>")]
     (first lines) => #"Error.*message"
     (re-find #"^>>>" (first lines)) => falsey
-    (count (map #(re-find #">>>implementation.util.t_exceptions" %) (rest lines))) => (count (rest lines))))
+    (count (remove nil? (map #(re-find #">>>implementation.util.fim_exceptions" %) (rest lines)))) => (count (rest lines))))
 
 (def nested-exception
   (ex-info "Found a NPE" {:info "wrapped throw of an NPE"} (NullPointerException.)))

--- a/test/implementation/util/fim_exceptions.clj
+++ b/test/implementation/util/fim_exceptions.clj
@@ -49,3 +49,20 @@
     (first lines) => #"Error.*message"
     (re-find #"^>>>" (first lines)) => falsey
     (count (map #(re-find #">>>implementation.util.t_exceptions" %) (rest lines))) => (count (rest lines))))
+
+(def nested-exception
+  (ex-info "Found a NPE" {:info "wrapped throw of an NPE"} (NullPointerException.)))
+
+(fact
+  "Check that exceptions with 'cause' data show the 'cause' stacktrace"
+  (let [lines (friendly-exception-lines nested-exception ">>>")]
+    (count (remove nil? (map #(re-find #">>>Caused by:" %) lines))) => 1))
+
+(def double-nested-exception
+  (ex-info "Exception with a cause chain 2 deep" {:info "2 deep"} nested-exception))
+
+(fact
+  "Check that exceptions with nested 'cause' data more than 1 level deep, shows
+  all 'cause' stacktraces"
+  (let [lines (friendly-exception-lines double-nested-exception ">>>")]
+    (count (remove nil? (map #(re-find #">>>Caused by:" %) lines))) => 2))


### PR DESCRIPTION
Currently midje does not show any information about the `cause` in an exception that is thrown. This PR modifies the exception pretty print code to include the 'caused by' stacktrace.

For example, say you have a function you want to test (`wrapped-sketchy-op` below) that catches an exception and throws a new exception that stores the caught exception as the cause.
```
(defn sketchy-op []
  (/ 1 0)) 

(defn wrapped-sketchy-op []
  (try
    (sketchy-op)
    (catch Exception e
      (throw (ex-info "Please don't be sketchy" {:info "sketch re-throw"} e)))))

(fact (wrapped-sketchy-op) => irrelevant)
```

Midje currently shows the following output
```
FAIL at (connection_test.clj:39)
    Expected: "calling 'wrapped-sketchy-op'"
      Actual: clojure.lang.ExceptionInfo: Please don't be sketchy {:info "sketch re-throw"}
              foo.bar.connection_test$wrapped_sketchy_op.invokeStatic(connection_test.clj:37)
              foo.bar.connection_test$wrapped_sketchy_op.invoke(connection_test.clj:33)
              foo.bar.connection_test$eval67747$fn__67748$fn__67749$fn__67750.invoke(connection_test.clj:39)
              foo.bar.connection_test$eval67747$fn__67748$fn__67749.invoke(connection_test.clj:39)
              foo.bar.connection_test$eval67747$fn__67748.invoke(connection_test.clj:39)
              foo.bar.connection_test$eval67747.invokeStatic(connection_test.clj:39)
              foo.bar.connection_test$eval67747.invoke(connection_test.clj:39)
```

In cases like this, the additional `cause` information is generally helpful to the developer. This PR changes the output to be the following:
```
FAIL at (connection_test.clj:39)
    Expected: "calling 'wrapped-sketchy-op'"
      Actual: clojure.lang.ExceptionInfo: Please don't be sketchy {:info "sketch re-throw"}
              foo.bar.connection_test$wrapped_sketchy_op.invokeStatic(connection_test.clj:37)
              foo.bar.connection_test$wrapped_sketchy_op.invoke(connection_test.clj:33)
              foo.bar.connection_test$eval67747$fn__67748$fn__67749$fn__67750.invoke(connection_test.clj:39)
              foo.bar.connection_test$eval67747$fn__67748$fn__67749.invoke(connection_test.clj:39)
              foo.bar.connection_test$eval67747$fn__67748.invoke(connection_test.clj:39)
              foo.bar.connection_test$eval67747.invokeStatic(connection_test.clj:39)
              foo.bar.connection_test$eval67747.invoke(connection_test.clj:39)

              Caused by: java.lang.ArithmeticException: Divide by zero
              foo.bar.connection_test$sketchy_op.invokeStatic(connection_test.clj:31)
              foo.bar.connection_test$sketchy_op.invoke(connection_test.clj:30)
              foo.bar.connection_test$wrapped_sketchy_op.invokeStatic(connection_test.clj:35)
              foo.bar.connection_test$wrapped_sketchy_op.invoke(connection_test.clj:33)
              foo.bar.connection_test$eval67747$fn__67748$fn__67749$fn__67750.invoke(connection_test.clj:39)
              foo.bar.connection_test$eval67747$fn__67748$fn__67749.invoke(connection_test.clj:39)
              foo.bar.connection_test$eval67747$fn__67748.invoke(connection_test.clj:39)
              foo.bar.connection_test$eval67747.invokeStatic(connection_test.clj:39)
```