### PR TITLE
Bump library versions and remove trailing whitespace

### DIFF
--- a/leiningen/timings.clj
+++ b/leiningen/timings.clj
@@ -20,7 +20,7 @@
                      (range 7)))]
      (println (sort array#))))
 
-(defn timings 
+(defn timings
   "Run both Midje and clojure.test tests.
    Namespaces are looked up in both the src/ and test/ subdirectories.
    If no namespaces are given, runs tests in all namespaces."
@@ -34,4 +34,4 @@
                      nil
                      nil
                      '(require '[clojure walk template stacktrace test string set]))))
-                     
+

--- a/project.clj
+++ b/project.clj
@@ -7,19 +7,19 @@
                  [marick/clojure-commons "3.0.0" :exclusions [org.clojure/clojure]]
                  ;; structural-typing currently broken with specter 0.13
                  ;; [marick/structural-typing "2.0.4" :exclusions [org.clojure/clojure org.clojure/clojurescript]]
-                 [org.clojure/math.combinatorics "0.1.3"]
+                 [org.clojure/math.combinatorics "0.1.4"]
                  [org.clojure/core.unify "0.5.7" :exclusions [org.clojure/clojure]]
-                 [clj-time "0.12.0" :exclusions [org.clojure/clojure]]
+                 [clj-time "0.13.0" :exclusions [org.clojure/clojure]]
                  [colorize "0.1.1" :exclusions [org.clojure/clojure]]
                  [org.clojure/tools.macro "0.1.5"]
                  [org.tcrawley/dynapath "0.2.5"]
                  [swiss-arrows "1.0.0" :exclusions [org.clojure/clojure]]
-                 [org.clojure/tools.namespace "0.2.10"]
+                 [org.clojure/tools.namespace "0.2.11"]
                  [flare "0.2.9" :exclusions [org.clojure/clojure]]
                  [slingshot "0.12.2"]]
-  :profiles {:dev {:dependencies [[prismatic/plumbing "0.5.3"]]
+  :profiles {:dev {:dependencies [[prismatic/plumbing "0.5.4"]]
                    :plugins [[lein-midje "3.2.1"]]}
-             :test-libs {:dependencies [[prismatic/plumbing "0.5.3"]]}
+             :test-libs {:dependencies [[prismatic/plumbing "0.5.4"]]}
              :1.7 [:test-libs {:dependencies [[org.clojure/clojure "1.7.0"]]}]
              :1.8 [:test-libs {:dependencies [[org.clojure/clojure "1.8.0"]]}]
              :1.9 [:test-libs {:dependencies [[org.clojure/clojure "1.9.0-alpha13"]]}]

--- a/src/midje/Bootstrap.clj
+++ b/src/midje/Bootstrap.clj
@@ -11,7 +11,7 @@
         ((ns-resolve 'midje.config 'load-config-files))
       (finally
         (in-ns saved-ns))))
-        
+
     (require 'midje.emission.api)
     ( (ns-resolve 'midje.emission.api 'load-plugin)
       ( (ns-resolve 'midje.config 'choice) :emitter))

--- a/src/midje/checkers.clj
+++ b/src/midje/checkers.clj
@@ -1,5 +1,5 @@
 (ns midje.checkers
-  "Checkers are for checking results of checkables, or checking 
+  "Checkers are for checking results of checkables, or checking
    that appropriate arguments are passed to prerequisites"
   (:require [such.vars :as var]
             [such.immigration :as immigrate])

--- a/src/midje/checking/checkables.clj
+++ b/src/midje/checking/checkables.clj
@@ -1,4 +1,4 @@
-(ns ^{:doc "Core Midje functions that process expects and report on their results."} 
+(ns ^{:doc "Core Midje functions that process expects and report on their results."}
   midje.checking.checkables
   (:require [commons.clojure.core :refer :all :exclude [any?]]
             [midje.checking.core :refer :all]
@@ -30,7 +30,7 @@
   (let [expected (:expected-result checkable-map)]
     (cond  (extended-= actual expected)
            (emit/pass)
-         
+
            (has-function-checker? checkable-map)
            (emit/fail (merge (minimal-failure-map :actual-result-did-not-match-checker
                                                   actual checkable-map)
@@ -41,11 +41,11 @@
                              ;; difficult to use evaluate-checking-function
                              ;; at the top of the cond
                              (second (evaluate-checking-function expected actual))))
-         
+
            (inherently-false-map-to-record-comparison? actual expected)
            (emit/fail (merge (minimal-failure-map :actual-result-did-not-match-expected-value actual checkable-map)
                              (map-record-mismatch-addition actual expected)))
-         
+
            :else
            (emit/fail (assoc (minimal-failure-map :actual-result-did-not-match-expected-value actual checkable-map)
                              :expected-result expected)))))
@@ -62,7 +62,7 @@
 
           (has-function-checker? checkable-map)
           (emit/fail (minimal-failure-map :actual-result-should-not-have-matched-checker actual checkable-map))
-        
+
           :else
           (emit/fail (minimal-failure-map :actual-result-should-not-have-matched-expected-value actual checkable-map)))))
 
@@ -79,7 +79,7 @@
 (defmethod call-count-incorrect? :fake [fake]
   (let [method (:times fake)
         count @(:call-count-atom fake)]
-    (branch-on method 
+    (branch-on method
       #(= % :default) (zero? count)
       number?         (not= method count)
       coll?           (not-any? (partial = count) method)
@@ -110,8 +110,8 @@
   (with-installed-fakes (concat (reverse (filter :data-fake (parse-background/background-fakes)))
                                 local-fakes
                                 (remove :data-fake (parse-background/background-fakes)))
-    (emission-boundary/around-check 
-      (let [actual (try  
+    (emission-boundary/around-check
+      (let [actual (try
                      (eagerly ((:function-under-test checkable-map)))
                     (catch Throwable ex
                       (captured-throwable ex)))]

--- a/src/midje/checking/checkers/chatty.clj
+++ b/src/midje/checking/checkers/chatty.clj
@@ -22,7 +22,7 @@
   (if (data-laden-falsehood? result)
     (assoc result :actual actual)
     result))
-  
+
 (defn chatty-worth-reporting-on? [arg]
   (and (or (list? arg) (seq? arg)) ; what started as a list (fn x y) might now be a seq.
        (pos? (count arg))
@@ -31,7 +31,7 @@
 (defn chatty-untease [result-symbol arglist]
   (reduce (fn [[complex-forms substituted-args] current-arg]
               (if (chatty-worth-reporting-on? current-arg)
-                [ (conj complex-forms current-arg), 
+                [ (conj complex-forms current-arg),
                   (conj substituted-args `(~result-symbol ~(count complex-forms))) ]
                 [complex-forms, (conj substituted-args current-arg)]))
       [[] []]

--- a/src/midje/checking/checkers/collection.clj
+++ b/src/midje/checking/checkers/collection.clj
@@ -45,14 +45,14 @@
               (throw (user-error (str "I don't know how to make sense of a "
                                       "regular expression applied "
                                       looseness "."))))
-        
+
         (not (collection-like? actual))
         (throw (user-error (str "You can't compare " (pr-str actual) " (" (type actual)
                                 ") to " (pr-str expected) " (" (type expected) ").")))
-        
+
         (inherently-false-map-to-record-comparison? actual expected)
         (throw (user-error (inherently-false-map-to-record-comparison-note actual expected)))
-        
+
         (and (map? actual)
              (not (map? expected)))
         (try (into {} expected)
@@ -65,7 +65,7 @@
   "Reduce arguments to standard forms so there are fewer combinations to
  consider. Also blow up for some incompatible forms."
   [actual expected looseness]
-  (compatibility-check actual expected looseness)  
+  (compatibility-check actual expected looseness)
   (cond
    (and (sequential? actual) (set? expected))                  [actual (vec expected) (union looseness #{:in-any-order })]
    (and (sequential? actual) (right-hand-singleton? expected)) [actual [expected] (union looseness #{:in-any-order })]
@@ -73,8 +73,8 @@
    (and (map? actual) (map? expected))  [actual expected looseness]
    (map? actual)                        [actual (into {} expected) looseness]
    (set? actual)                        (recur (vec actual) expected looseness-modifiers)
-   (and (string? actual)               
-        (not (string? expected))       
+   (and (string? actual)
+        (not (string? expected))
         (not (regex? expected)))        (recur (vec actual) expected looseness-modifiers)
         :else                                [actual expected looseness]))
 
@@ -104,10 +104,10 @@
                       :else (let [[actual expected looseness] (standardized-arguments actual expected looseness)]
                               (cond (regex? expected)
                                     (try-re (pattern-fn expected) actual re-find)
-                                    
+
                                     (expected-fits? actual expected)
                                     (match? (take-fn (count expected) actual) expected looseness)
-                                    
+
                                     :else (noted-falsehood
                                            (cl-format nil
                                                       "A collection with ~R element~:P cannot match a ~A of size ~R."
@@ -146,7 +146,7 @@
   ^{:midje/checker true
     :doc "Checks that the expected result is a subsequence of the actual result:
 
-To succeed, f's result must be (1) contiguous and (2) in the 
+To succeed, f's result must be (1) contiguous and (2) in the
 same order as in the contains clause. Here are examples:
 
    [3 4 5 700]   => (contains [4 5 700]) ; true
@@ -169,7 +169,7 @@ The two modifiers can be used at the same time:
    [4 5 'hi 700]     => (contains [4 5 700] :in-any-order :gaps-ok) ; true
    [700 'hi 4 5 'hi] => (contains [4 5 700] :in-any-order :gaps-ok) ; true
 
-Another way to indicate :in-any-order is to describe 
+Another way to indicate :in-any-order is to describe
 what's contained by a set. The following two are equivalent:
 
    [700 4 5] => (contains [4 5 700] :in-any-order)
@@ -188,8 +188,8 @@ what's contained by a set. The following two are equivalent:
 
 (def ; just
   ^{:midje/checker true
-    :doc "A variant of contains, just, will fail if the 
-left-hand-side contains any extra values:   
+    :doc "A variant of contains, just, will fail if the
+left-hand-side contains any extra values:
    [1 2 3] => (just [1 2 3])  ; true
    [1 2 3] => (just [1 2 3 4]) ; false
 
@@ -222,10 +222,10 @@ just is also useful if you don't care about order:
                                                             (count expected)
                                                             (count actual))))))))
 
-(defchecker has 
-  "You can apply Clojure's quantification functions (every?, some, and so on) 
+(defchecker has
+  "You can apply Clojure's quantification functions (every?, some, and so on)
    to all the values of sequence.
-   
+
    Ex. (fact (f) => (has every? odd?))"
   [quantifier predicate]
   (checker [actual]
@@ -240,10 +240,10 @@ just is also useful if you don't care about order:
                     (vals actual)
                     actual)))))
 
-(defchecker n-of 
-  "Checks whether a sequence contains precisely n results, and 
+(defchecker n-of
+  "Checks whether a sequence contains precisely n results, and
    that they each match the checker.
-  
+
   Ex. (fact (repeat 100 :a) => (n-of :a 100))"
   [expected expected-count]
 
@@ -254,12 +254,12 @@ just is also useful if you don't care about order:
 (defmacro #^:private generate-n-of-checkers []
   (pile/macro-for [[num num-word] [[1 "one"] [2 "two"] [3 "three"] [4 "four"] [5 "five"]
                                    [6 "six"] [7 "seven"] [8 "eight"] [9 "nine"] [10 "ten"]]]
-    (let [name (symbol (str num-word "-of"))                                                                 
+    (let [name (symbol (str num-word "-of"))
           docstring (cl-format nil "Checks whether a sequence contains precisely ~R result~:[s, and \n  that they each match~;, and \n  that it matches~] the checker.
-  
+
    Ex. (fact ~A => (~C :a))" num (= num 1) (vec (repeat num :a )) name)]
-      `(defchecker 
-         ~name 
+      `(defchecker
+         ~name
          ~docstring
          {:arglists '([~'expected])}
          [expected#]

--- a/src/midje/checking/checkers/collection_comparison.clj
+++ b/src/midje/checking/checkers/collection_comparison.clj
@@ -62,7 +62,7 @@
           (pile/function-name item)
           (pr-str item)))
       " (in that order)"))
-  
+
   (defmethod best-expected-match ::map [midje-classification comparison expected]
     (best-expected-match-wrapper midje-classification
       comparison
@@ -143,7 +143,7 @@
 
                 :else
                 (better-of candidate best-so-far)))))
-        
+
         (order-free-compare-results [expected expected-permutations try-permutation]
           (loop [expected-permutations expected-permutations
                  best-so-far (base-starting-candidate expected)]
@@ -154,7 +154,7 @@
                   comparison
                   (recur (rest expected-permutations)
                     (better-of comparison best-so-far)))))))
-        
+
         (feasible-permutations
           ;; "Permute the given list if it contains inexact checkers.
           ;;  Only produces all permutations for short lists."
@@ -195,7 +195,7 @@
     [actual expected looseness]
     (let [starting-candidate (base-starting-candidate expected)
           gaps-ok? (some (partial = :gaps-ok) looseness)]
-  
+
       ;; This embeds two loops. walking-actual controls the inner loop. It walks
       ;; until success or it hits a mismatch. actual controls the outer loop.
       ;; Upon each mismatch, it tries again with the #'rest of itself.
@@ -204,10 +204,10 @@
              walking-expected expected
              best-so-far      starting-candidate
              candidate        starting-candidate]
-  
+
         (cond (or (empty? walking-actual) (empty? walking-expected))
           (better-of candidate best-so-far)
-  
+
           (extended-= (first walking-actual) (first walking-expected))
           ;; actual good so far, keep working on it
           (recur actual
@@ -217,7 +217,7 @@
             (map/conj-into candidate
               :actual-found (first walking-actual)
               :expected-found (first walking-expected)))
-  
+
           (and gaps-ok? (not (empty? (rest walking-actual))))
           ;; This is a gap in the walking actual. Skip it.
           (recur actual
@@ -225,7 +225,7 @@
             walking-expected
             best-so-far
             candidate)
-  
+
           (not (empty? actual))
           ;; See if we can find something better later on.
           (recur (rest actual)

--- a/src/midje/checking/checkers/collection_diffs.clj
+++ b/src/midje/checking/checkers/collection_diffs.clj
@@ -21,15 +21,15 @@
 (defmethod contains:diffs :map:map [actual-map expected-map _]
   (let [[actual-keys expected-keys] (map #(set (keys %)) [actual-map expected-map])
         missing-keys (difference expected-keys actual-keys)
-        
-        diff-map (reduce (fn [so-far shared-key] 
+
+        diff-map (reduce (fn [so-far shared-key]
                            (let [[actual-val expected-val] (map shared-key [actual-map expected-map])
                                  comparison (core/extended-= actual-val expected-val)]
                              (cond (core/extended-true? comparison)
                                    so-far
 
                                    (core/data-laden-falsehood? comparison)
-                                   (do 
+                                   (do
                                      (prn "data laden falsehood " comparison)
                                      (assoc so-far shared-key (new AtomDiff actual-val expected-val)))
 

--- a/src/midje/checking/checkers/combining.clj
+++ b/src/midje/checking/checkers/combining.clj
@@ -21,7 +21,7 @@
          ~to-wrap))))
 
 (defmacro every-checker
-  "Combines multiple checkers into one checker that passes 
+  "Combines multiple checkers into one checker that passes
    when all component checkers pass. If one checker fails,
    the remainder are not run. The output shows which checker
    failed.
@@ -45,14 +45,14 @@
   [& checker-forms]
   (let [actual-gensym (gensym "actual-result-")
         check-result-gensym (gensym "check-result-")
-        checks-form (reduce (fn [to-wrap checker-form] 
+        checks-form (reduce (fn [to-wrap checker-form]
                               (wrap-in-and-checking-form checker-form to-wrap
                                                          check-result-gensym
                                                          actual-gensym))
                             'true
                             (reverse checker-forms))]
     `(checker [~actual-gensym] ~checks-form)))
-                       
+
 
 (defn- ^{:testable true}
   wrap-in-or-checking-form [checker-form to-wrap actual-sym]
@@ -62,7 +62,7 @@
        ~to-wrap)))
 
 (defmacro some-checker
-  "Combines multiple checkers into one checker that passes 
+  "Combines multiple checkers into one checker that passes
    when any of the component checkers pass. If one checker
    passes, the remainder are not run. Example:
 
@@ -78,7 +78,7 @@
    "
   [& checker-forms]
   (let [actual-gensym (gensym "actual-result-")
-        checks-form (reduce (fn [to-wrap checker-form] 
+        checks-form (reduce (fn [to-wrap checker-form]
                               (wrap-in-or-checking-form checker-form to-wrap
                                                         actual-gensym))
                             'false

--- a/src/midje/checking/checkers/defining.clj
+++ b/src/midje/checking/checkers/defining.clj
@@ -29,7 +29,7 @@
           (if (vector? (first arglists+bodies))
             (recur checker-name docstring attr-map (list arglists+bodies))
             (let [arglists (map first arglists+bodies)]
-              (make-checker-definition checker-name 
+              (make-checker-definition checker-name
                                        docstring
                                        attr-map
                                        arglists

--- a/src/midje/checking/checkers/simple.clj
+++ b/src/midje/checking/checkers/simple.clj
@@ -11,16 +11,16 @@
 ;;; DANGER: If you add a checker, add it to ../checkers.clj
 
 
-(defchecker truthy 
+(defchecker truthy
   "Returns precisely true if actual is not nil and not false."
-  [actual] 
+  [actual]
   (and (not (captured-throwable? actual))
        (boolean actual)))
 (ns/defalias TRUTHY truthy)
 
-(defchecker falsey 
+(defchecker falsey
   "Returns precisely true if actual is nil or false."
-  [actual] 
+  [actual]
   (not actual))
 (ns/defalias FALSEY falsey)
 
@@ -69,7 +69,7 @@
        (fact (foo) => (throws IOException)
        (fact (foo) => (throws IOException #\"No such file\")
 
-   `throws` takes three kinds of arguments: 
+   `throws` takes three kinds of arguments:
    * A class argument requires that the Throwable be of that class.
    * A string or regular expression requires that the `message` of the Throwable
      match the argument.

--- a/src/midje/checking/core.clj
+++ b/src/midje/checking/core.clj
@@ -53,7 +53,7 @@
     [false {:thrown ex}])))
 
 (defn extended-= [actual expected]
-  (try  
+  (try
     (cond
      (data-laden-falsehood? actual)      actual
      (data-laden-falsehood? expected)    expected

--- a/src/midje/checking/facts.clj
+++ b/src/midje/checking/facts.clj
@@ -3,7 +3,7 @@
   (:require [midje.config :as config]
             [midje.emission.boundaries :as emission-boundary]
             [midje.data.compendium :as compendium]))
-                  
+
 ;;; Fact execution utilities
 
 (defn check-one [fact]
@@ -17,10 +17,10 @@
           (not (fact-creation-filter fact))
           (str "This fact was ignored because of the current configuration. "
                "Only facts matching "
-               (vec (map #(if (fn? %) "<some function>" %) 
+               (vec (map #(if (fn? %) "<some function>" %)
                          (:created-from (meta fact-creation-filter))))
                " will be created.")
-            
+
           :else-top-level-fact-to-check
           (emission-boundary/around-top-level-fact fact {}
             ;; The fact is recorded on entry so that if a fact is

--- a/src/midje/config.clj
+++ b/src/midje/config.clj
@@ -7,7 +7,7 @@
             [midje.data.fact :as fact]
             [commons.clojure.core :as core]
             [such.function-makers :as mkfn]))
-  
+
 ;;; I consider whether we're running in the repl part of the config. This matters because
 ;;; threads can't examine the stack to see if they're in the repl. So we check once at
 ;;; startup time.
@@ -49,7 +49,7 @@
       (throw (user-error (str "These are not configuration keys: " (vec extras))))))
   (dorun (map validate-key! changes)))
 
-  
+
 (defmacro with-augmented-config
   "Dynamically bind the configuration. Example:
    (require '[clojure.config :as config])
@@ -69,13 +69,13 @@
   "Returns the configuration value of `key`"
   [key] (*config* key))
 
-(defn merge-permanently! 
+(defn merge-permanently!
   "Merges the given map into the root configuration.
    Does not affect any temporary (dynamic) configurations."
   [additions]
   (validate! additions)
   (alter-var-root #'*config* merge additions))
-  
+
 (defn change-defaults
   "Adds key-value pairs to the root configuration.
    Does not affect any temporary (dynamic) configurations.

--- a/src/midje/data/compendium.clj
+++ b/src/midje/data/compendium.clj
@@ -18,10 +18,10 @@
   (named-fact [this namespace name])
   (fact-with-guid [this namespace guid])
   (previous-version [this fact-function]))
-    
+
 
 ;; The compendium has three maps, each keyed by a namespace name.
-;; 
+;;
 ;; One maps that namespace to a list of facts (in the order in which
 ;; the facts were defined, which is usually the order of facts in the file.
 ;; This map is sorted alphabetically.
@@ -37,8 +37,8 @@
     (throw (user-error (str "You tried to work with `" symbol-or-namespace
                              "` but that namespace has never been loaded."))))
   (ns-name symbol-or-namespace))
-  
-  
+
+
 
 (defrecord Compendium [by-namespace by-name by-guid last-fact-checked]
   CompendiumProtocol
@@ -46,7 +46,7 @@
     (let [[namespace name guid]
           ( (juxt fact/namespace fact/name fact/guid)
             fact-function)]
-      (-> this 
+      (-> this
           (assoc-in [:by-namespace namespace]
                     (conj (by-namespace namespace []) fact-function))
           (#(if name
@@ -77,7 +77,7 @@
              (not (find-ns namespace)))
       this
       (let [namespace-name (friendly-ns-name namespace)]
-        (-> this 
+        (-> this
             (map/dissoc-keypath [:by-namespace namespace-name])
             (map/dissoc-keypath [:by-name namespace-name])
             (map/dissoc-keypath [:by-guid namespace-name])))))

--- a/src/midje/data/fact.clj
+++ b/src/midje/data/fact.clj
@@ -2,7 +2,7 @@
   midje.data.fact
   (:refer-clojure :exclude [name namespace]))
 
-                  
+
 ;;; This is a potential target for migrating the non-parsing,
 ;;; non-checking parts of ideas/facts.clj, ideas/metadata.clj. It's
 ;;; sketchy now, since it's only being used to keep the emission
@@ -12,7 +12,7 @@
   [:midje/source :midje/guid :midje/file :midje/line :midje/namespace
    :midje/name :midje/description :midje/top-level?])
 
-(defn make-getters 
+(defn make-getters
   "Create midje.data.fact/name midje.data.fact/file, etc."
   [in-namespace prefix]
   (doseq [property-key fact-properties]

--- a/src/midje/data/metaconstant.clj
+++ b/src/midje/data/metaconstant.clj
@@ -1,4 +1,4 @@
-(ns ^{:doc "A notation that avoids confusion between what’s essential 
+(ns ^{:doc "A notation that avoids confusion between what’s essential
             about data and what’s accidental. A stand in for constant data."}
   midje.data.metaconstant
   (:require [midje.util.ecosystem :as ecosystem]
@@ -62,8 +62,8 @@
   (entryAt [this key]
            (find storage key))
   (assoc [this key val]
-    ;; (Metaconstant. (.underlying-symbol this) (assoc storage key val))) 
-    (throw (exceptions/user-error 
+    ;; (Metaconstant. (.underlying-symbol this) (assoc storage key val)))
+    (throw (exceptions/user-error
             (str "Metaconstants (" (.underlying-symbol this) ") can't have values assoc'd onto them.")
             "If you have a compelling need for that, please create an issue:"
             ecosystem/issues-url)))

--- a/src/midje/data/prerequisite_state.clj
+++ b/src/midje/data/prerequisite_state.clj
@@ -27,8 +27,8 @@
 
 
 ;;; Handling mocked calls
-  
-(defmulti ^{:private true} call-handled-by-fake? (fn [function-var actual-args fake] 
+
+(defmulti ^{:private true} call-handled-by-fake? (fn [function-var actual-args fake]
                                                    (:type fake)))
 
 (defmethod call-handled-by-fake? :not-called [function-var actual-args fake]
@@ -62,7 +62,7 @@
 
 
 
-(defn- ^{:testable true } best-call-action 
+(defn- ^{:testable true } best-call-action
   "Returns a fake: when one can handle the call
    Else returns a function: from the first fake with a usable-default-function.
    Returns nil otherwise."
@@ -71,8 +71,8 @@
     (throw (apply exceptions/user-error (parse-fakes/disallowed-function-failure-lines function-var))))
   (if-let [found (find-first (partial call-handled-by-fake? function-var actual-args) fakes)]
     found
-    (when-let [fake-with-usable-default (find-first #(and (= function-var (:var %)) 
-                                                          (usable-default-function? %)) 
+    (when-let [fake-with-usable-default (find-first #(and (= function-var (:var %))
+                                                          (usable-default-function? %))
                                                     fakes)]
       (default-function fake-with-usable-default))))
 
@@ -87,14 +87,14 @@
       (branch-on action
         extended-fn?
         (apply action actual-args)
-        
+
         map?
         (do
           (swap! (:call-count-atom action) inc)
           ((:result-supplier action )))
-        
+
         :else
-        (do 
+        (do
           (emit/fail {:type :prerequisite-was-called-with-unexpected-arguments
                       :var function-var
                       :actual actual-args
@@ -108,10 +108,10 @@
 (defn- fn-fakes-binding-map [fn-fakes]
   (let [var->faker-fn (fn [the-var]
                         (-> (fn [& actual-args]
-                              (handle-mocked-call the-var actual-args fn-fakes)) 
+                              (handle-mocked-call the-var actual-args fn-fakes))
                             (vary-meta assoc :midje/faked-function true)))
         fn-fake-vars (map :var fn-fakes)]
-    (zipmap fn-fake-vars 
+    (zipmap fn-fake-vars
             (map var->faker-fn fn-fake-vars))))
 
 (defn- data-fakes-binding-map [data-fakes]
@@ -120,7 +120,7 @@
 
 (defn binding-map [fakes]
   (let [[data-fakes fn-fakes] (seq/bifurcate :data-fake fakes)]
-    (merge (fn-fakes-binding-map fn-fakes) 
+    (merge (fn-fakes-binding-map fn-fakes)
            (data-fakes-binding-map data-fakes))))
 
 (defmacro with-installed-fakes [fakes & forms]

--- a/src/midje/doc.clj
+++ b/src/midje/doc.clj
@@ -34,9 +34,9 @@
    user's guide.
    "} midje)
 
-  
+
 ;; midje-repl
-(def ^{:doc 
+(def ^{:doc
   "
   Here are Midje repl functions. Use `doc` for more info on each one.
   To control verbosity of output, use the print levels described by
@@ -78,7 +78,7 @@
 
   ----- Fetching facts
   Same notation as the `check-facts` family, but with
-  \"fetch\" instead of \"check\". 
+  \"fetch\" instead of \"check\".
   To check the returned facts, use `check-one-fact`:
      (map check-one-fact (fetch-facts :all))
 
@@ -107,9 +107,9 @@
   verbose way:
     (check-facts :all 2)
     (check-facts :all :print-facts)
-  
+
   Here are all the variants:
-  
+
   :print-normally     (0)  -- failures and a summary.
   :print-no-summary  (-1)  -- failures only.
   :print-nothing     (-2)  -- nothing is printed.
@@ -130,7 +130,7 @@
       (let [result (prime-ish 5)]
         result => odd?
         result => (roughly 13)))
-     
+
   * Nested facts
     (facts \"about life\"
       (facts \"about birth\"...)
@@ -143,7 +143,7 @@
       ?x   ?y
        1    2
        0    3)
-      
+
   * Metadata
     (fact :integration ...)
     (fact {:priority 5} ...)
@@ -202,7 +202,7 @@
 
        (def unnatural-number (some-checker (complement number?) odd? neg?))
        (fact 'fred => unnatural-number)
-  "} midje-defining-checkers)        
+  "} midje-defining-checkers)
 
 (def ^{:doc "
   * Prerequisites and top-down TDD:
@@ -213,7 +213,7 @@
          (chars ..row..) => [..five.. ..three..]
          (char-value ..five..) => \"5\"
          (char-value ..three..) => \"3\"))
-          
+
   * Prerequisites can be defaulted for claims within a fact:
     (fact \"No one is ready until everyone is ready.\"
       (prerequisites (pilot-ready?) => true,
@@ -223,7 +223,7 @@
       (ready?) => falsey (provided (pilot-ready?) => false)
       (ready?) => falsey (provided (copilot-ready?) => false)
       (ready?) => falsey (provided (flight-engineer-ready?) => false))
-          
+
   * Prerequisites apply to nested facts
     (facts \"about airplanes\"
        (prerequisites (wings) => 2
@@ -232,7 +232,7 @@
              (prerequisite (crew) => 8)
              ...)))
 "} midje-prerequisites)
-       
+
 
 (def ^{:doc
        "
@@ -256,7 +256,7 @@
     5     =not=>    even?      ; Invert the check. Synonym: =deny=>
     (f)   =future=> halts      ; don't check, but issue reminder.
     (m x) =expands-to=> form   ; expand macro and check result
-          
+
   * In prerequisites
     ..meta.. =contains=> {:a 1} ; partial specification of map-like object
     (f)      =streams=>  (range 5 1000)
@@ -273,19 +273,19 @@
 
   If you want different configurations for repl and command-line
   Midje, use the `running-in-repl?` predicate.
-  
+
   You can temporarily override the configuration like this:
       (midje.config/with-augmented-config {:print-level :print-no-summary}
          <forms>...)
-  
+
   ------ Configuration keywords
   :print-level                  ; Verbosity of printing.
                                 ; See `(doc midje-print-levels)`.
-  
+
   :visible-deprecation          ; Whether information about deprecated
                                 ; features or functions is printed.
                                 ; Default: true.
-  
+
   :visible-future               ; Whether future facts produce output.
                                 ; Default: true.
                                 ; More: `(guide future-facts)`
@@ -297,13 +297,13 @@
   :fact-filter                  ; A function applied to the metadata of
                                 ; a fact to see if it should be checked.
                                 ; Default: (constantly true)
-  
+
   :check-after-creation         ; Should facts be checked as they're loaded?
                                 ; Default: true.
 
   :emitter                      ; Namespace or pathname that contains
                                   an \"emitter\" of custom output.
-  
+
   :partial-prerequisites        ; Whether the real function can be used.
                                 ; Default false.
                                 ; More: `(guide partial-prerequisites)`
@@ -380,13 +380,13 @@
 (def guide-urls (map second (partition 2 guide-raw)))
 
 (def guide-map (zipmap guide-topics guide-urls))
-                    
+
 (defmacro guide
   "Open a web page that addresses a particular topic"
   ([topic]
      `(if-let [url# (guide-map '~topic)]
         (browse/browse-url url#)
-        (do 
+        (do
           (println "There is no such topic. Did you mean one of these?")
           (doseq [topic# guide-topics]
             (println "   " topic#)))))

--- a/src/midje/emission/api.clj
+++ b/src/midje/emission/api.clj
@@ -54,7 +54,7 @@
   (when (and (config-above? :print-nothing)
              (config/choice :visible-future))
     (bounce-to-plugin :future-fact description position)))
-  
+
 (defn forget-everything []
   (bounce-to-plugin :starting-fact-stream)
   ;; This happens after the `forget-everything` so that
@@ -90,8 +90,8 @@
        (bounce-to-plugin :finishing-fact-stream (state/output-counters) clojure-test-results)))
   ([]
      (fact-stream-summary {:test 0})))
-                                 
-;;; 
+
+;;;
 
 (defmacro producing-only-raw-fact-failures [& body]
   `(config/at-print-level :print-nothing

--- a/src/midje/emission/boundaries.clj
+++ b/src/midje/emission/boundaries.clj
@@ -14,7 +14,7 @@
 
           (zero? failures)
           true
-        
+
           :else
           false)))
 
@@ -22,7 +22,7 @@
   {:failures (+ (state/output-counters:midje-failures)
                 (:fail ct-counters)
                 (:error ct-counters))})
-  
+
 
 ;; TODO: Once we reconcile the different ways results are checked and
 ;; returned by these two macros, extract commonality into a helper
@@ -68,4 +68,4 @@
   `(do ~@body))
 
 
-  
+

--- a/src/midje/emission/clojure_test_facade.clj
+++ b/src/midje/emission/clojure_test_facade.clj
@@ -18,7 +18,7 @@
 
 
 (defn run-tests
-  "Run clojure.test tests in the given namespaces. It does not 
+  "Run clojure.test tests in the given namespaces. It does not
    affect the Midje fact counters but instead returns a map
    that can be used to produce a separate report."
   [namespaces]

--- a/src/midje/emission/colorize.clj
+++ b/src/midje/emission/colorize.clj
@@ -1,4 +1,4 @@
-(ns ^{:doc "Functions dealing with making various forms of 
+(ns ^{:doc "Functions dealing with making various forms of
             Midje output be ergonomically colorful."}
   midje.emission.colorize
   (:require [colorize.core :as color]
@@ -27,7 +27,7 @@
       (def fail color/red)
       (def pass color/green)
       (def note color/cyan))
-    
+
     "REVERSE"
     (do
       (def fail color/red-bg)

--- a/src/midje/emission/plugins/default.clj
+++ b/src/midje/emission/plugins/default.clj
@@ -41,19 +41,19 @@
                       (if (= 1 fails)
                         (str (color/fail "FAILURE:") (format " %d check failed." fails))
                         (str (color/fail "FAILURE:") (format " %d checks failed." fails))))
-          
+
                     (midje-consolation []
                       (condp = passes
                         0 ""
                         (format " (But %d succeeded.)" passes)))]
-              
+
               (vector
                (cond (zero? (+ passes fails))
                      (color/note "No facts were checked. Is that what you wanted?")
-                     
+
                      (zero? fails)
                      (color/pass (format "All checks (%d) succeeded." passes))
-                     
+
                      :else
                      (str (midje-failure-summary) " " (midje-consolation))))))
 
@@ -77,7 +77,7 @@
   (util/emit-one-line "")
   (util/emit-one-line (str (color/note "WORK TO DO") " "
                            (when-let [doc (util/format-nested-descriptions description-list)]
-                             (str (pr-str doc) " "))                           
+                             (str (pr-str doc) " "))
                            "at " (util/filename-lineno position))))
 
 (defn make-map [& keys]
@@ -92,5 +92,5 @@
                                    :possible-new-namespace
                                    :finishing-fact-stream
                                    :starting-fact-stream)))
-  
+
 (state/install-emission-map emission-map)

--- a/src/midje/emission/plugins/default_failure_lines.clj
+++ b/src/midje/emission/plugins/default_failure_lines.clj
@@ -14,7 +14,7 @@
     (cons "    The checker said this about the reason:"
           (indented (:notes m)))))
 
-(defn- intermediate-results [m] 
+(defn- intermediate-results [m]
   (if (:intermediate-results m)
     (cons "    During checking, these intermediate values were seen:"
           (for [[form value] (:intermediate-results m)]
@@ -51,7 +51,7 @@
      (str "      Actual: " (attractively-stringified-value (:actual m)))
      (diffs [actual expected])
      (notes m))))
-    
+
 (defmethod messy-lines :actual-result-should-not-have-matched-expected-value [m]
   (list
    (str "    Expected: Anything BUT " (attractively-stringified-value (:expected-result m)))
@@ -80,8 +80,8 @@
                   msg (cond
                        (and (= :default exp) (zero? act))
                        "[expected at least once, actually never called]"
-                  
-                       :else 
+
+                       :else
                        (cl-format nil "[expected :times ~A, actually called ~R time~:P]" exp act))]
               (str "    " (:expected-result-form fail) " " msg)))]
     (cons

--- a/src/midje/emission/plugins/progress.clj
+++ b/src/midje/emission/plugins/progress.clj
@@ -18,7 +18,7 @@
 (defn fail [failure-map]
   (print (color/fail "F"))
   (flush))
-  
+
 (defn future-fact [description-list position]
   (print (color/note "P"))
   (flush))

--- a/src/midje/emission/plugins/util.clj
+++ b/src/midje/emission/plugins/util.clj
@@ -10,7 +10,7 @@
             [midje.config :as config]
             [midje.util.ordered-map :as om]
             [midje.util.ordered-set :as os]))
-  
+
 
 
 ;; The theory here was that using clojure.test output would allow text
@@ -161,7 +161,7 @@
       (filename-lineno [filename line-num]))))
 
 
-(defn- format-binding-map [binding-map] 
+(defn- format-binding-map [binding-map]
   (let [formatted-entries (for [[k v] binding-map]
                             (str (pr-str k) " " (pr-str v)))]
     (str "[" (str/join "\n                           " formatted-entries) "]")))

--- a/src/midje/emission/state.clj
+++ b/src/midje/emission/state.clj
@@ -14,7 +14,7 @@
        ~@body
      (finally
        ((ns-resolve '~ns '~set-name) original-value#)))))
-    
+
 
 (defmacro make-counter-atom [name & keys]
   (let [atom-name (symbol (str name "-atom"))
@@ -45,8 +45,8 @@
          (defn ~reset-name [] (reset! ~atom-name ~fresh-name))
          (~reset-name)
          ~(make-defmacro)
-         ~@(map make-one-getter keys) 
-         ~@(map make-one-setter keys) 
+         ~@(map make-one-getter keys)
+         ~@(map make-one-setter keys)
          ~@(map make-one-incrementer keys)))))
 
 
@@ -77,4 +77,4 @@
 (defmacro with-emission-map [map & body]
   `(binding [emission-functions ~map]
      ~@body))
-  
+

--- a/src/midje/parsing/0_to_fact_form/formulas.clj
+++ b/src/midje/parsing/0_to_fact_form/formulas.clj
@@ -14,12 +14,12 @@
 
 ;; Formulas work by running up to *num-trials* trials per formula.
 (def ^{:doc "The number of trials generated per formula."
-       :dynamic true} 
-  *num-trials* 100)   
+       :dynamic true}
+  *num-trials* 100)
 
-(set-validator! #'*num-trials* 
+(set-validator! #'*num-trials*
   (fn [new-val]
-    (if (pos? new-val) 
+    (if (pos? new-val)
       true
       (throw (Error. (str "*num-trials* must be an integer 1 or greater. You tried to set it to: " new-val))))))
 
@@ -39,10 +39,10 @@
 
 
 (defn- check-part-of [form]
-  (prewalk (fn [form] 
+  (prewalk (fn [form]
              (if (some (partial first-named? form) ["against-background" "background" "provided"])
-                 '() 
-                 form)) 
+                 '()
+                 form))
     form))
 
 (defn valid-pieces [[_formula_ & args :as form]]
@@ -50,25 +50,25 @@
         invalid-keys (remove (partial = :num-trials) (keys opts-map))]
     (cond (not (leaves-contain-arrow? (check-part-of args)))
           (error/report-error form "There is no expection in your formula form:")
-    
+
           (> (count (leaf-expect-arrows (check-part-of args))) 1)
           (error/report-error form "There are too many expections in your formula form:")
-  
+
           (or (not (vector? bindings))
               (odd? (count bindings))
               (< (count bindings) 2))
           (error/report-error form "Formula requires bindings to be an even numbered vector of 2 or more:")
-  
+
           (some #(and (named? %) (= "background" (name %))) (flatten args))
           (error/report-error form "background cannot be used inside of formula")
-  
+
           (not (empty? invalid-keys))
           (error/report-error form (format "Invalid keys (%s) in formula's options map. Valid keys are: :num-trials" (join ", " invalid-keys)))
-          
-          (and (:num-trials opts-map) 
+
+          (and (:num-trials opts-map)
                (not (pos? (:num-trials opts-map))))
           (error/report-error form (str ":num-trials must be an integer 1 or greater. You tried to set it to: " (:num-trials opts-map))))
-      
+
     [docstring? opts-map bindings body]))
 
 
@@ -85,21 +85,21 @@
        (emit/fail failure#)
        (emit/pass))))
 
-(defmacro formula 
-  "Generative-style fact macro. 
-  
-  Ex. (formula \"any two strings concatenated begins with the first\" 
-        [a (gen/string) b (gen/string)] 
+(defmacro formula
+  "Generative-style fact macro.
+
+  Ex. (formula \"any two strings concatenated begins with the first\"
+        [a (gen/string) b (gen/string)]
         (str a b) => (has-prefix a))
-        
-  Currently, we recommend you use generators from test.generative.generators. 
-   
+
+  Currently, we recommend you use generators from test.generative.generators.
+
   opts-map keys:
-  
-     :num-trials - Used to override the number of trials for this formula only. 
+
+     :num-trials - Used to override the number of trials for this formula only.
                    This is higher precedence than *num-trials*
                    Must be set to a number 1 or greater.
-  
+
   The *num-trials* dynamic var determines
   how many facts are generated per formula."
   {:arglists '([docstring? opts-map? bindings & body])}

--- a/src/midje/parsing/1_to_explicit_form/metadata.clj
+++ b/src/midje/parsing/1_to_explicit_form/metadata.clj
@@ -22,7 +22,7 @@
                   add-key (fn [key value] (assoc metadata key value))]
 
               (cond (recognize/start-of-checking-arrow-sequence? body)
-                    [metadata body] 
+                    [metadata body]
 
                     (string? head)
                     (recur (add-key :midje/description head) (rest body))
@@ -36,7 +36,7 @@
 
                     (map? head)
                     (recur (merge metadata head) (rest body))
-                    
+
                     :else
                     [metadata body])))]
     (let [[metadata body] (basic-parse {:midje/source `'~metadata-containing-form
@@ -65,17 +65,17 @@
         description (:midje/description metadata)
         namelike (cond (and name (not description))
                        [(symbol name)]
-                       
+
                        (and description (not name))
                        (throw (Error. "This case is impossible"))
-                       
+
                        (and (not description) (not name))
                        []
-                       
+
                        (= description name)
                        [description]
-                       
-                       :else 
+
+                       :else
                        [(symbol name) description])
         maplike (apply dissoc metadata (filter #(re-find #"^:midje/" (str %)) (keys metadata)))]
     (if (empty? maplike)
@@ -89,7 +89,7 @@
         stripped-top-level-body `((~(first lower-level-form) ~@lower-level-body) ~@(rest top-level-body))]
       [(merge lower-level-meta top-level-meta {:midje/guid (random/form-hash stripped-top-level-body)})
        stripped-top-level-body]))
-       
+
 
 (defn separate-multi-fact-metadata
   "This does not include metadata specified by strings or symbols."
@@ -98,10 +98,10 @@
          [x & xs :as body] forms]
     (cond (keyword? x)
           (recur (assoc metadata x true) xs)
-          
+
           (map? x)
           (recur (merge metadata x) xs)
-          
+
           :else
           [metadata body])))
 

--- a/src/midje/parsing/1_to_explicit_form/parse_background.clj
+++ b/src/midje/parsing/1_to_explicit_form/parse_background.clj
@@ -27,7 +27,7 @@
   (namespace-values-inside-out :midje/background-fakes))
 
 
-;; Dissecting background changers. The TERMINOLOGY file will help you understand this.
+;; Dissecting background changers. The TERMINOLOGY file will help you understand this.
 
 (defn separate-extractable-background-changing-forms [fact-body-forms]
   (letfn [(definitely-extractable-form? [form]
@@ -49,7 +49,7 @@
 
 
 
-;; Dealing with a list of background changers
+;; Dealing with a list of background changers
 
 (defn- first-form-is-no-state-changer? [forms]
   (or (not (commons/linear-access? (first forms)))
@@ -92,7 +92,7 @@
 
 
 
-;; State changes are converted into unification templates. The unification happens when
+;; State changes are converted into unification templates. The unification happens when
 ;; individual bodies of code (facts, checkables, etc.) are processed.
 
 (defn- at-substitution-loc? [loc]

--- a/src/midje/parsing/2_to_lexical_maps/expects.clj
+++ b/src/midje/parsing/2_to_lexical_maps/expects.clj
@@ -21,7 +21,7 @@
           expanded-fakes (map (fn [fake]
                                  ;; TODO: Maybe this wants to be a multimethod,
                                  ;; but I'm not sure whether the resemblance between
-                                 ;; data-fakes and regular fakes isn't too coincidental. 
+                                 ;; data-fakes and regular fakes isn't too coincidental.
                                  (cond (first-named? fake "fake")
                                        (parse-fakes/to-lexical-map-form fake)
 
@@ -32,12 +32,12 @@
                                        (macroexpand fake)
 
                                        :else
-                                       (do 
+                                       (do
                                          (prn "Now here's a peculiar thing to find inside a check: " fake)
                                          fake)))
                                fakes)]
       `(midje.checking.checkables/check-one ~check ~(vec expanded-fakes)))
-             
+
     recognize/macroexpansion-check-arrow?
     (let [expanded-macro `(macroexpand-1 '~call-form)
           escaped-expected-result `(quote ~expected-result)]
@@ -50,7 +50,7 @@
 
     recognize/parse-exception-arrow?
     (throw (java.lang.ClassNotFoundException. "A test asked for an exception"))
-    
+
     :else
     (throw (Error. (str "Program error: Unknown arrow form " arrow)))))
 
@@ -66,7 +66,7 @@
 (defn to-lexical-map-form [full-form]
   (apply expansion (valid-pieces full-form)))
 
-(defmacro expect 
+(defmacro expect
   {:arglists '([call-form arrow expected-result & fakes+overrides])}
   [& _]
   (to-lexical-map-form &form))

--- a/src/midje/parsing/2_to_lexical_maps/fakes.clj
+++ b/src/midje/parsing/2_to_lexical_maps/fakes.clj
@@ -51,7 +51,7 @@
           (error/report-error call-form
                               "The first value in a prerequisite's call form has to be a var or a symbol."
                               (cl-format nil "~S starts with a keyword." call-form))
-     
+
           (compiler-will-inline-fn? (actual-var))
           (error/report-error call-form
                               (cl-format nil "You cannot override the function `~S`: it is inlined by the Clojure compiler." (actual-var)))
@@ -79,10 +79,10 @@
 (defn to-lexical-map-form [a-list]
   (assert-right-shape! a-list)
   (apply lexical-maps/fake (valid-pieces a-list)))
-    
-(defmacro fake 
+
+(defmacro fake
   "Creates a fake map that a particular call will be made. When it is made,
-   the result is to be returned. Either form may contain bound variables. 
+   the result is to be returned. Either form may contain bound variables.
    Example: (let [a 5] (fake (f a) => a))"
   {:arglists '([call-form arrow result & overrides])}
   [& _]

--- a/src/midje/parsing/2_to_lexical_maps/folded_fakes.clj
+++ b/src/midje/parsing/2_to_lexical_maps/folded_fakes.clj
@@ -9,7 +9,7 @@
             [midje.util.pile :as pile]
             [such.maps :as map]))
 
-;; Note that unfolding is done after prerequisites are converted to fakes. 
+;; Note that unfolding is done after prerequisites are converted to fakes.
 
 ;; General strategy is to condense fake forms into a funcall=>metaconstant
 ;; mapping. These substitutions are used both to "flatten" a fake form and also
@@ -45,13 +45,13 @@
 
   (defn augment-substitutions [substitutions fake-form]
     (let [needed-keys (filter mockable-funcall? (fake-form-funcall-arglist fake-form))]
-      ;; Note: because I like for a function's metaconstants to be    
-      ;; easily mappable to the original fake, I don't make one       
-      ;; unless I'm sure I need it.                                   
-      (into substitutions (for [needed-key needed-keys 
+      ;; Note: because I like for a function's metaconstants to be
+      ;; easily mappable to the original fake, I don't make one
+      ;; unless I'm sure I need it.
+      (into substitutions (for [needed-key needed-keys
                                 :when (nil? (get substitutions needed-key))]
                             [needed-key (metaconstant-for-form needed-key)]))))
-  
+
   (defn folded-fake? [form]
     (and (sequential? form)
          (= `fake (first form))
@@ -68,23 +68,23 @@
 
 (defn- ^{:testable true } unfolding-step
   "This walks through a `pending` list that may contain fakes. Each element is
-   copied to the `finished` list. If it is a suitable fake, its nested 
+   copied to the `finished` list. If it is a suitable fake, its nested
    are flattened (replaced with a metaconstant). If the metaconstant was newly
    generated, the fake that describes it is added to the pending list. In that way,
-   it'll in turn be processed. This allows arbitrarily deep nesting." 
+   it'll in turn be processed. This allows arbitrarily deep nesting."
   [finished pending substitutions]
   (let [target (first pending)]
     (if-not (folded-fake? target)
-      [(conj finished target), 
-       (rest pending), 
+      [(conj finished target),
+       (rest pending),
        substitutions]
-    
+
       (let [overrides (drop 4 target)
             augmented-substitutions (augment-substitutions substitutions target)
             flattened-target (flatten-fake target augmented-substitutions)
             generated-fakes (generate-fakes (map/key-difference augmented-substitutions substitutions) overrides)]
-        [(conj finished flattened-target), 
-         (concat generated-fakes (rest pending)), 
+        [(conj finished flattened-target),
+         (concat generated-fakes (rest pending)),
          augmented-substitutions]))))
 
 

--- a/src/midje/parsing/3_from_lexical_maps/from_fake_maps.clj
+++ b/src/midje/parsing/3_from_lexical_maps/from_fake_maps.clj
@@ -51,7 +51,7 @@
 
 (defmethod mkfn:result-supplier =throws=> [_arrow_ throwable]
   (fn []
-    (when-not (instance? Throwable throwable) 
+    (when-not (instance? Throwable throwable)
       (throw (exceptions/user-error "Right side of =throws=> should extend Throwable.")))
     (throw throwable)))
 

--- a/src/midje/parsing/arrow_symbols.clj
+++ b/src/midje/parsing/arrow_symbols.clj
@@ -2,45 +2,45 @@
   midje.parsing.arrow-symbols)
 
 (def ^{:doc "As a checking arrow: the left side should result in the right side.
-  As a prerequisite arrow: the fake should return the thing on the right."} 
+  As a prerequisite arrow: the fake should return the thing on the right."}
   => "=>")
 
-(def ^{:doc "Checking arrow. The left side should NOT result in the right side."} 
+(def ^{:doc "Checking arrow. The left side should NOT result in the right side."}
   =not=> "=not=>")
 
-(def ^{:doc "Checking arrow. The left side should NOT result in the right side."} 
+(def ^{:doc "Checking arrow. The left side should NOT result in the right side."}
   =deny=> "=deny=>")
 
-(def ^{:doc "Checking arrow. The left side should macroexpand-1 to the right side."} 
+(def ^{:doc "Checking arrow. The left side should macroexpand-1 to the right side."}
   =expands-to=> "=expands-to=>")
 
-(def ^{:doc "Checking arrow. The check won't evaluate, but will 
-  leave a 'WORK TO DO' reminder in the report."} 
+(def ^{:doc "Checking arrow. The check won't evaluate, but will
+  leave a 'WORK TO DO' reminder in the report."}
   =future=> "=future=>")
 
-(def ^{:doc "Data prerequisite arrow.  
-  Ex. (fact 
+(def ^{:doc "Data prerequisite arrow.
+  Ex. (fact
         (:a ..m..) => 1
-        (provided ..m.. =contains=> {:a 1}))"} 
+        (provided ..m.. =contains=> {:a 1}))"}
   =contains=> "=contains=>")
 
-(def ^{:doc "Prerequisite arrow. The fake will return the first element 
-  of the given sequence the first time the fake is evaluated, the second 
-  element the second time, and so on. Note, that each element is only 
-  evaluated when needed, thus in the below example the exception is 
+(def ^{:doc "Prerequisite arrow. The fake will return the first element
+  of the given sequence the first time the fake is evaluated, the second
+  element the second time, and so on. Note, that each element is only
+  evaluated when needed, thus in the below example the exception is
   never thrown.
 
   Ex. (def tally [] (+ (bar) (bar) (bar)))
       (fact (tally) => 6
-        (provided (bar) =streams=> [1 2 3 (throw (Exception.))]))"} 
+        (provided (bar) =streams=> [1 2 3 (throw (Exception.))]))"}
   =streams=> "=streams=>")
 
-(def ^{:doc "Prerequisite arrow. The fake will throw the Throwable on 
+(def ^{:doc "Prerequisite arrow. The fake will throw the Throwable on
   the right side of the arrow.
 
   Ex. (def f [] (g))
       (fact (f) => (throws IllegalArgumentException. \"boom\")
-        (provided (g) =throws=> (IllegalArgumentException. \"boom\")))"} 
+        (provided (g) =throws=> (IllegalArgumentException. \"boom\")))"}
   =throws=> "=throws=>")
 
 (def ^{:doc "Use this when testing Midje code that processes arrow-forms"}

--- a/src/midje/parsing/other/arglists.clj
+++ b/src/midje/parsing/other/arglists.clj
@@ -17,7 +17,7 @@
     (when (seq extras)
       (throw (user-error "You have extra print level names or numbers.")))
     (dorun (map levels/validate-level! (filter number? args)))
-      
+
     (if print-level
       [[print-level]  print-level   non-levels]
       [[           ]  default       non-levels])))
@@ -54,19 +54,19 @@
           (loop [so-far {:true-args (vec true-args)}
                  flag-selector (zipmap (map set flag-descriptions)
                                        (map first flag-descriptions))
-                                       
+
                  flag-segments flag-segments]
             (let [[[flag] flag-args] (take 2 flag-segments)
                   matching-selector (first (filter #(% flag) (keys flag-selector)))]
               (cond (empty? flag-segments)
                     [(vals flag-selector) so-far]
-                    
+
                     matching-selector
                     (recur (assoc so-far (build-on-flag-keyword (flag-selector matching-selector) "?") true
                                   (build-on-flag-keyword (flag-selector matching-selector) "-args") (vec flag-args))
                            (dissoc flag-selector matching-selector)
                            (drop 2 flag-segments))
-                    
+
                     :else
                     (throw (Error. (str "It should be impossible for a flag-segment not to match a selector."
                                         (pr-str flag-descriptions arglist)))))))]
@@ -74,6 +74,6 @@
              (zipmap (map #(build-on-flag-keyword % "?") unmentioned-keys)
                      (repeat false))))))
 
-               
-          
-          
+
+
+

--- a/src/midje/parsing/util/core.clj
+++ b/src/midje/parsing/util/core.clj
@@ -49,7 +49,7 @@
     (vec transformed-form)
     transformed-form))
 
-(defn reader-line-number 
+(defn reader-line-number
   "Find what line number the reader put on the given form or on
    one of its elements. If no line numbers, a warning string."
   [form]

--- a/src/midje/parsing/util/fnref.clj
+++ b/src/midje/parsing/util/fnref.clj
@@ -21,7 +21,7 @@
   `(var ~reference))
 (defmethod as-var-form :var-form [reference]
   reference)
-  
+
 (defmulti as-form-to-fetch-var-value classify-function-reference)
 (defmethod as-form-to-fetch-var-value :symbol [reference]
   reference)
@@ -36,4 +36,4 @@
   (resolve reference))
 (defmethod resolved-to-actual-var-object :var-form [reference]
   (resolved-to-actual-var-object (second reference)))
-  
+

--- a/src/midje/parsing/util/future_variants.clj
+++ b/src/midje/parsing/util/future_variants.clj
@@ -3,9 +3,9 @@
   (:require [midje.parsing.util.core :refer :all]
             [midje.util.pile :as pile]))
 
-(def future-prefixes ["future-" 
-                      "pending-" 
-                      "incipient-" 
+(def future-prefixes ["future-"
+                      "pending-"
+                      "incipient-"
                       "antiterminologicaldisintactitudinarian-"])
 
 (def future-fact-variant-names (for [prefix future-prefixes

--- a/src/midje/parsing/util/recognizing.clj
+++ b/src/midje/parsing/util/recognizing.clj
@@ -23,7 +23,7 @@
 
 
 (defn expect-match-or-mismatch [arrow]
-  (condp = (name arrow) 
+  (condp = (name arrow)
     => :expect-match
     =expands-to=> :expect-match
     =not=> :expect-mismatch
@@ -70,7 +70,7 @@
 (defn provided? [loc]
   (boolean (and (symbol? (zip/node loc))
                 (= "provided" (name (zip/node loc))))))
-  
+
 (defn metaconstant-prerequisite? [[lhs arrow rhs & overrides :as fake-body]]
   (symbol-named? arrow =contains=>))
 

--- a/src/midje/parsing/util/wrapping.clj
+++ b/src/midje/parsing/util/wrapping.clj
@@ -1,17 +1,17 @@
-(ns ^{:doc "midje.background uses these to wrap extra code around 
+(ns ^{:doc "midje.background uses these to wrap extra code around
             :contents, :facts, or :expects"}
   midje.parsing.util.wrapping
   (:require [clojure.zip :as zip]
             [midje.parsing.util.core :refer :all]
-            [midje.util.thread-safe-var-nesting :refer [namespace-values-inside-out 
+            [midje.util.thread-safe-var-nesting :refer [namespace-values-inside-out
                                                         set-namespace-value
-                                                        with-pushed-namespace-values]] 
+                                                        with-pushed-namespace-values]]
             [midje.util.unify :as unify]
             [such.sequences :as seq]))
 
 
 (defn midje-wrapped
-  "This is used to prevent later wrapping passes from processing 
+  "This is used to prevent later wrapping passes from processing
    the code-that-produces-the-value."
   [value] value)
 
@@ -32,7 +32,7 @@
   (vary-meta what assoc :midje/wrapping-target target))
 
 (defn for-wrapping-target? [target]
-  (fn [actual] 
+  (fn [actual]
     (= target (:midje/wrapping-target (meta actual)))))
 
 (defmacro with-additional-wrappers [final-wrappers form]

--- a/src/midje/parsing/util/zip.clj
+++ b/src/midje/parsing/util/zip.clj
@@ -2,7 +2,7 @@
   midje.parsing.util.zip
   (:require [clojure.zip :as zip]))
 
-;;; Copied from utilize to remove dependencies. 
+;;; Copied from utilize to remove dependencies.
 ;;; https://github.com/AlexBaranosky/Utilize
 (defn unchunk
   "Force a lazy sequence to not use size 32 chunks, but true one-element laziness"
@@ -56,4 +56,4 @@
 
 (defn previous-form [loc]
   (zip/node (previous-loc loc)))
-  
+

--- a/src/midje/production_mode.clj
+++ b/src/midje/production_mode.clj
@@ -9,8 +9,8 @@
                                 namespace-symbol
                                 " is loaded.")))))]
 
-  (defn user-desires-checking? 
-    "If clojure.test/*load-tests* or midje.sweet/include-midje-checks 
+  (defn user-desires-checking?
+    "If clojure.test/*load-tests* or midje.sweet/include-midje-checks
     is false, facts won't run."
     []
     (and (value-within 'clojure.test '*load-tests*)

--- a/src/midje/util/bultitude.clj
+++ b/src/midje/util/bultitude.clj
@@ -73,19 +73,19 @@
                 true
                 (throw (Exception.))) ; not just implausible: flat out impossible/invalid.
               false))
-            
+
           (next-form []
-            (try 
+            (try
               (let [form (read rdr false ::done)]
                 (cond (= ::done form)
                       ::done
 
                       (plausible-ns-form? form)
-                      (do 
+                      (do
                         (str form) ;; force the read to read the whole form, throwing on error
                         (second form))
 
-                      :else 
+                      :else
                       ::boring-form))
               (catch Exception _
                 ::broken-namespace)))]
@@ -97,7 +97,7 @@
                              {:status :contains-namespace, :namespace-symbol form}))))
 
 (defn- extend-starting-classification [classification]
-  (letfn [(grovel-through-bytes [] 
+  (letfn [(grovel-through-bytes []
             (with-open [r (PushbackReader. ((:reader-maker classification)))]
               (describe-namespace-status r)))]
     (if (not (readable? classification))

--- a/src/midje/util/debugging.clj
+++ b/src/midje/util/debugging.clj
@@ -11,7 +11,7 @@
 ;; Add more functions as needed.
 
 
-;;; Copied from utilize to remove dependencies. 
+;;; Copied from utilize to remove dependencies.
 ;;; https://github.com/AlexBaranosky/Utilize
 
 (defn but-last-str [#^String s n]
@@ -47,5 +47,5 @@
 
 (defn nopret
   "A no-op. Adding 'no' is easier than deleting a 'pret'."
-  [val] 
+  [val]
   val)

--- a/src/midje/util/ecosystem.clj
+++ b/src/midje/util/ecosystem.clj
@@ -11,7 +11,7 @@
             such.versions))
 
 (def issues-url "https://github.com/marick/Midje/issues")
-(def syntax-errors-that-will-not-be-fixed     
+(def syntax-errors-that-will-not-be-fixed
   "https://github.com/marick/Midje/wiki/Syntax-errors-that-will-not-be-fixed")
 
 
@@ -25,7 +25,7 @@
 
 ;;
 
-(defn getenv [var] 
+(defn getenv [var]
   (System/getenv var))
 
 (defn on-windows? []
@@ -82,7 +82,7 @@
       (load-file "project.clj")
     (catch java.io.FileNotFoundException e
         (set-leiningen-paths! {:test-paths ["test"]})))))
- 
+
 (defn leiningen-paths []
   (or leiningen-paths-var
       (do

--- a/src/midje/util/exceptions.clj
+++ b/src/midje/util/exceptions.clj
@@ -4,9 +4,9 @@
             [midje.util.ecosystem :refer [line-separator]]))
 
 
-;;; Creating 
+;;; Creating
 
-(defn user-error 
+(defn user-error
   "Used when a user does something off-limits or incompatible"
   [& lines]
   (Error. (join line-separator lines)))
@@ -53,14 +53,14 @@
 (defprotocol ICapturedThrowable
   (throwable [this])
   (friendly-stacktrace [this]))
-                       
-(deftype CapturedThrowable [ex] 
-  ICapturedThrowable 
+
+(deftype CapturedThrowable [ex]
+  ICapturedThrowable
   (throwable [this] ex)
   (friendly-stacktrace [this]
     (join line-separator (friendly-exception-lines (throwable this) "              "))))
 
-(defn captured-throwable [ex] 
+(defn captured-throwable [ex]
   (CapturedThrowable. ex))
 
 (defn captured-throwable? [x]

--- a/src/midje/util/pile.clj
+++ b/src/midje/util/pile.clj
@@ -23,7 +23,7 @@
 (defn sort-map [m]
   (into (sorted-map) m))
 
-;;; Copied from utilize to remove dependencies. 
+;;; Copied from utilize to remove dependencies.
 ;;; https://github.com/AlexBaranosky/Utilize
 (defn ordered-zipmap [keys vals]
   "Like zipmap, but guarantees order of the entries"
@@ -31,7 +31,7 @@
          ks (seq keys)
          vs (seq vals)]
     (if (and ks vs)
-      (recur (assoc m (first ks) (first vs)) 
+      (recur (assoc m (first ks) (first vs))
              (next ks)
              (next vs))
       m)))
@@ -55,11 +55,11 @@
 
 (defn apply-pairwise
   "(apply-pairwise [inc dec] [1 1] [2 2]) => [ [2 0] [3 1] ]
-   Note that the functions must take only a single argument." 
+   Note that the functions must take only a single argument."
   [functions & arglists]
-  (map (partial map 
-  		(fn [f arg] (f arg)) 
-  		functions) 
+  (map (partial map
+  		(fn [f arg] (f arg))
+  		functions)
   	arglists))
 
 (defn pop-if
@@ -69,29 +69,29 @@
     [(first args) (rest args)]
     [nil args]))
 
-(def pop-docstring 
+(def pop-docstring
   ;; "Extracts optional map from head of args"
   (partial pop-if string?))
 
-(def pop-opts-map 
+(def pop-opts-map
   ;; "Extracts optional docstring from head of args"
   (partial pop-if map?))
 
 
 ;;; Definition helpers
 
-(defmacro macro-for 
-  "Macroexpands the body once for each of the elements in the 
+(defmacro macro-for
+  "Macroexpands the body once for each of the elements in the
    right-side argument of the bindings, which should be a seq"
-  [bindings body] 
+  [bindings body]
   `(let [macros# (for ~bindings
                      ~body)]
     `(do ~@macros#)))
 
-(defmacro def-many-methods 
-  "Create multiple multimethods with different dispatch values 
+(defmacro def-many-methods
+  "Create multiple multimethods with different dispatch values
    but the same implementation"
-  [name dispatch-vals args & body] 
+  [name dispatch-vals args & body]
   (macro-for [dval dispatch-vals]
     `(defmethod ~name ~dval ~args
        ~@body)))

--- a/src/midje/util/thread_safe_var_nesting.clj
+++ b/src/midje/util/thread_safe_var_nesting.clj
@@ -40,7 +40,7 @@
 
 
 ;; Values associated with namespaces
-(defn set-namespace-value [key-name newval] 
+(defn set-namespace-value [key-name newval]
   (alter-meta! *ns* assoc key-name newval))
 
 (defn destroy-namespace-value [key-name]

--- a/src/midje/util/unify.clj
+++ b/src/midje/util/unify.clj
@@ -8,11 +8,11 @@
 (defn substitute
   "Attempts to substitute the bindings into any symbol in the given form."
   [form bindings]
-  (prewalk (fn [expr] 
+  (prewalk (fn [expr]
                 (if (and (symbol? expr)
                          (contains? bindings expr))
                   (bindings expr)
-                  expr)) 
+                  expr))
                 form))
 
 (defn ?form [] (symbol (name (ns-name *ns*)) "?form")) ; this cannot be right

--- a/test/as_documentation/about_defrecord/generic.clj
+++ b/test/as_documentation/about_defrecord/generic.clj
@@ -1,6 +1,6 @@
 (ns as-documentation.about-defrecord.generic)
 
-;; Here's a simple protocol. To cover various cases, there's two arities for `bump` and 
+;; Here's a simple protocol. To cover various cases, there's two arities for `bump` and
 ;; `twice` begs out to use `bump` in its implementation.
 ;;
 ;; This namespace is named `generic` because the functions declared by records/types

--- a/test/as_documentation/about_defrecord/using_as__plain_tests/specific.clj
+++ b/test/as_documentation/about_defrecord/using_as__plain_tests/specific.clj
@@ -10,16 +10,16 @@
   (bound? #'generic/bump) => true)
 
 
-;; Note that self-calls require qualification with the generic namespace. 
-;; #'bump and #'twice are not bound at this point. That makes for confusing 
-;; declarations like 
+;; Note that self-calls require qualification with the generic namespace.
+;; #'bump and #'twice are not bound at this point. That makes for confusing
+;; declarations like
 ;;
 ;;   (bump [this] (generic/bump this 1))
 ;;
 ;; Why doesn't the first instance of the token `bump` need namespace qualification? It's
 ;; really special-case processing by the macros that make up the defrecord/deftype
 ;; complex. You *can* use a qualified name if you like:
-;; 
+;;
 ;;   (generic/bump [this] (generic/bump this 1))
 ;;
 ;; ... and everything work the same. However, that's not idiomatic.
@@ -35,7 +35,7 @@
   (ecosystem/when-1-6+
    ;; This throws a null-pointer exception in older Clojures
    (find-var 'as-documentation.about-defrecord.generic/using-as--plain-tests.specific/bump) => falsey))
-  
+
 (fact "Therefore, even within this namespace uses of the record must use the generic function's var"
   (let [rec (->Record 3)]
     (generic/bump rec) => 4

--- a/test/as_documentation/about_defrecord/using_as__provided_tests/specific.clj
+++ b/test/as_documentation/about_defrecord/using_as__provided_tests/specific.clj
@@ -7,12 +7,12 @@
   (:require [as-documentation.about-defrecord.generic :as generic]))
 
 ;; In contrast to the `defrecord` case (in `using_as__plain_tests/specific.clj`), the
-;; fact that the var-having-a-function-associated-with-it belongs to another package 
+;; fact that the var-having-a-function-associated-with-it belongs to another package
 ;; must be made explicit. That is, we could there do:
 ;;   (bump [_ by] (+ n by))
-;; ... but here we must do 
+;; ... but here we must do
 ;;   (generic/bump [_ by] (+ n by))
-;; This is unexpected enough that I consider it a bug. (Though you could argue that 
+;; This is unexpected enough that I consider it a bug. (Though you could argue that
 ;; its `defrecord`'s special-casing that's the original sin.)
 
 ;; However, such variation from `defrecord` is not required in the
@@ -30,7 +30,7 @@
     (generic/bump rec) => 4
     (generic/bump rec 5) => 8
     (generic/twice rec) => 6))
-  
+
 (fact "and you can now mock out one of these methods"
   (let [rec (->Record 3)]
     (+ 1 (generic/bump rec)) => 0

--- a/test/as_documentation/about_defrecord/using_refer__provided_tests/specific.clj
+++ b/test/as_documentation/about_defrecord/using_refer__provided_tests/specific.clj
@@ -32,4 +32,4 @@
     (provided
       (bump rec 3) => ..bogus..)))
 
-  
+

--- a/test/as_documentation/checkers/defining.clj
+++ b/test/as_documentation/checkers/defining.clj
@@ -126,7 +126,7 @@
 (note-that fact-fails)
 
 ;; This fails with this message (as of April 2012):
-;;   
+;;
 ;;   FAIL at (t_defining_checkers.clj:105)
 ;;   Actual result did not agree with the checking function.
 ;;           Actual result: {:foo 1, :bar "foo"}
@@ -161,7 +161,7 @@
            (fact-gave-intermediate-result (string? (:bar actual-map)) => true)
            (fact-gave-intermediate-result (= (count (:bar actual-map)) expected-count) => false))
 
-           
+
 
 
 ;; If you want a simpler checker that doesn't take arguments, just use
@@ -190,8 +190,8 @@
 ;;
 ;; In truth, you probably wouldn't use chatty checkers for boolean
 ;; expressions, because chatty checkers don't stop after the first failure,
-;; which is usually desirable. Instead, you'd use `every-checker` or `some-checker`. 
-  
+;; which is usually desirable. Instead, you'd use `every-checker` or `some-checker`.
+
 (fact 4 => (some-checker even? odd?))
 
 (silent-fact 4 => (every-checker odd? (roughly 3)))

--- a/test/as_documentation/checkers/for_maps_and_records.clj
+++ b/test/as_documentation/checkers/for_maps_and_records.clj
@@ -26,7 +26,7 @@
 (for-failure 2 (note-that (fact-failed-with-note "A record on the right of the arrow means the value on the left must be of the same type.")))
 
 ;; The =not=> arrow is a tricky case. Consider this:
-;; 
+;;
 ;; (fact
 ;;   {:x 1, :y 2} =not=> (R. 1 2}
 ;;
@@ -47,7 +47,7 @@
 (fact (R. 1 2) =not=> (R. 1 3333333))
 (silent-fact (R. 1 2) =not=> (R. 1 2))
 (note-that fact-failed)
-           
+
 
 
 

--- a/test/as_documentation/checkers/for_sequences.clj
+++ b/test/as_documentation/checkers/for_sequences.clj
@@ -18,11 +18,11 @@
 
   (fact "as a side note, you can also use `three-of` instead of the previous checkable"
     ["a" "aa" "aaa"] => (three-of #"a+")))
-    
+
 
 (fact "when `just` takes no options, you can omit brackets"
   [1 2 3] => (just odd? even? odd?))
-    
+
 
 (fact "you can specify that order is irrelevant"
   [1 3 2] => (just [1 2 3] :in-any-order)
@@ -58,23 +58,23 @@
 (fact ":in-any-order or set arguments are also supported"
   [5 1 4 2] => (contains [1 2 5] :gaps-ok :in-any-order)
   [5 1 4 2] => (contains #{1 2 5} :gaps-ok))
-  
+
 
                                 ;;; has-prefix, has-suffix
 
 (fact "has-prefix is anchored to the left"
     [1 2 3] =not=> (has-prefix [2 3])     ; it's not a prefix
-    [1 2 3] =>     (has-prefix [1 2])     
+    [1 2 3] =>     (has-prefix [1 2])
     [1 2 3] =not=> (has-prefix [2 1])     ; order matters
     [1 2 3] =>     (has-prefix [2 1] :in-any-order)
     [1 2 3] =>     (has-prefix #{2 1}))
 
 (fact "has-suffix is anchored to the left"
-    [1 2 3] =>     (has-suffix [2 3])     
+    [1 2 3] =>     (has-suffix [2 3])
     [1 2 3] =not=> (has-suffix [1 2])     ; not a suffix
     [1 2 3] =not=> (has-suffix [3 2])     ; order matters
     [1 2 3] =>     (has-suffix [3 2] :in-any-order)
-    [1 2 3] =>     (has-suffix #{3 2}))  
+    [1 2 3] =>     (has-suffix #{3 2}))
 
                                 ;;; has
 
@@ -98,7 +98,7 @@
   ;; ...
   [1 3 5 7 9 11 13 15 17] => (nine-of odd?)
   ["a" "b" "c" "d" "e" "f" "g" "h" "i" "j"] => (ten-of string?)
-  
+
   ;; to go above ten-of
   (repeat 100 "a") => (n-of "a" 100))
 
@@ -107,4 +107,4 @@
   [:k :w :extra :keywords] =not=> (two-of keyword?))
 
 
-  
+

--- a/test/as_documentation/configuration.clj
+++ b/test/as_documentation/configuration.clj
@@ -33,7 +33,7 @@
 
 (fact "changes are restricted to that scope"
   (config/choice :print-level) =not=> :print-nothing)
-  
+
 
 ;; Changing the print level is a common enough operation
 ;; (for at least Midje's own tests) that it has its own
@@ -43,6 +43,6 @@
 (fact "`at-print-level` changes the print level within a scope"
   (config/at-print-level :print-nothing
     (config/choice :print-level) => :print-nothing))
-     
+
 (fact "changes are restricted to that scope"
   (config/choice :print-level) =not=> :print-nothing)

--- a/test/as_documentation/fact_groups.clj
+++ b/test/as_documentation/fact_groups.clj
@@ -3,9 +3,9 @@
             [midje.repl :refer :all]
             [midje.test-util :refer :all]))
 
-;;; Fact groups are used to supply metadata to the enclosed top-level facts. 
+;;; Fact groups are used to supply metadata to the enclosed top-level facts.
 ;;; For example, here are two facts that would cause failures if checked.
-;;; They're not checked because we'll only check facts that aren't slow. 
+;;; They're not checked because we'll only check facts that aren't slow.
 
 (config/with-augmented-config {:check-after-creation false}
   (fact-group :slow
@@ -34,4 +34,4 @@
     ;; The metadata below does nothing.
     (fact {:slow false} "fact-third" => :will-fail-when-run)))
 
-(check-facts *ns* :print-no-summary :filter (complement :slow)) 
+(check-facts *ns* :print-no-summary :filter (complement :slow))

--- a/test/as_documentation/facts.clj
+++ b/test/as_documentation/facts.clj
@@ -4,10 +4,10 @@
             [midje.test-util :refer :all]))
 
 ;; Midje's test suite is configured not to show some output that's demonstrated here.
-;; This resets Midje's setting back to the default. 
+;; This resets Midje's setting back to the default.
 (config/with-augmented-config {:visible-future true}
 
-                                            ;;; Basics 
+                                            ;;; Basics
 
   ;; This is the simplest form of a fact. It has two *checkables*.
   (fact "addition works in Clojure"
@@ -15,15 +15,15 @@
     ;; for this file.
     (+ 10 10) => 20
     (+ 20 20) => 40)
-  
+
   ;; Facts do not have to have descriptions
-  (fact 
+  (fact
     (+ 10 10) => 20
     (+ 20 20) => 40)
-  
+
   (facts "`Facts` is a synonym for `fact`. It doesn't require multiple checkables."
     (+ 1 1) => 2)
-  
+
   (silent-fact "Checkables fail individually."
     (+ 1 1) => 2
     (+ 2 2) => 3)
@@ -35,12 +35,12 @@
     (+ 1 "0") => 1
     (note-that fact-fails,
                (fact-captured-throwable-with-message #"Right side of =throws=> should extend Throwable")))
-  
+
 
                                          ;;; Todos / future facts
-  
+
   ;; Future facts act as TODO statements.
-  (capturing-fact-output 
+  (capturing-fact-output
    (future-fact "do something someday")
    (fact @fact-output => #"WORK TO DO.*do something someday"))
 
@@ -52,5 +52,5 @@
      @fact-output => (contains "WORK TO DO")
      @fact-output => (contains "on `(- 1 1)`")
      @fact-output => #"facts.clj:\d\d"))
-  
+
 )

--- a/test/as_documentation/metaconstants.clj
+++ b/test/as_documentation/metaconstants.clj
@@ -41,7 +41,7 @@
 
 (defn choose-interesting-arg [& args]
   (first (filter interesting? args)))
-  
+
 (fact
   (choose-interesting-arg ..first.. ..second..) => ..second..
   (provided
@@ -66,7 +66,7 @@
   (provided
     (--v-- 1 2 3) => 8))
 
-    
+
 ;; Metaconstants can also be used in background prerequisites, like this:
 
 (future-fact "This is a design flaw: background and 'local' prerequisites should be merged"

--- a/test/as_documentation/prerequisites/aaaaaa_the_basics.clj
+++ b/test/as_documentation/prerequisites/aaaaaa_the_basics.clj
@@ -23,11 +23,11 @@
     (fetch-project-paths) => ["test"]
     (provided
       (read-project-file) =throws=> (Error. "boom!"))))
-  
+
 
 ;;; A version with metaconstants. Plain metaconstants have only one
 ;;; property: identity. If you see a metaconstant twice in the same
-;;; checkable, you know it's the same value each time. 
+;;; checkable, you know it's the same value each time.
 
 (fact "fetch-project-paths returns the project file's test and source paths, in that order"
   (fetch-project-paths) => [..test1.. ..test2.. ..source..]
@@ -69,7 +69,7 @@
 
     (gpa ..student.. coursework) => (roughly correct-gpa tolerance)
     (provided (child-of-wealthy-alumnus? ..student..) => false)
-    
+
     (gpa ..student.. coursework) => (roughly (+ correct-gpa 0.5) tolerance)
     (provided (child-of-wealthy-alumnus? ..student..) => true)))
 
@@ -97,7 +97,7 @@
 
 
 
-;; You also get a helpful failure for an unused prerequisite:       
+;; You also get a helpful failure for an unused prerequisite:
 
 (capturing-failure-output
  (fact
@@ -141,7 +141,7 @@
   (provided
     (lower-function 5) => 50 :times [1 2]
     (lower-function 6) =>  5))
- 
+
 ;; You can also use a lazy sequence:
 
 (silent-fact
@@ -160,7 +160,7 @@
   (top-function 5) => 55
   (provided
     (lower-function 0) => 88 :times (range)
-    (lower-function 5) => 50 
+    (lower-function 5) => 50
     (lower-function 6) =>  5))
 
 ;; The idiom for saying a function is not called is annoying:
@@ -187,13 +187,13 @@
 ;;; However, plain (non-checker) functions are matched literally. In the following,
 ;;; the `provided` means that the the specific function `even?` is to be passed to
 ;;; `hilbertian`.
-  
+
 (unfinished hilbertian)
 
 (defn function-under-test [n]
   (hilbertian (if (pos? n) even? odd?)))
 
-(fact 
+(fact
   (function-under-test 3) => ..hilbertian-result..
   (provided
     (hilbertian even?) => ..hilbertian-result..))
@@ -236,7 +236,7 @@
     (find-letter) => ..letter-result..
     (provided
       (letter desired-letter & anything) => ..letter-result..)))
-    
+
 (fact "You can even apply a checker to the &rest argument"
   (find-letter) => ..letter-result..
   (provided
@@ -244,7 +244,7 @@
     (letter & (contains ["x" "y"])) => ..letter-result..))
 
 
-  
+
 
 
 
@@ -264,7 +264,7 @@
   (provided
     (first-est 1 5) => ..some-result..
     (second-est ..some-result..) => 100))
-    
+
 ;; But it could be more tersely expressed like this:
 
 (fact

--- a/test/as_documentation/prerequisites/fact_wide.clj
+++ b/test/as_documentation/prerequisites/fact_wide.clj
@@ -2,7 +2,7 @@
   (:require [midje.sweet :refer :all]))
 
 ;;; Here is a simple motivating example. Suppose you have a predicate `pilot-ready?` that
-;;; depends on other predicates. 
+;;; depends on other predicates.
 
 (unfinished pilot-ready? copilot-ready? engines-ready?)
 
@@ -17,7 +17,7 @@
   (prerequisites (pilot-ready? ..flight..) => true
                  (copilot-ready? ..flight..) => true
                  (engines-ready? ..flight..) => true)
-  
+
   (flight-ready? ..flight..) => truthy
   (flight-ready? ..flight..) => falsey (provided (pilot-ready? ..flight..) => false)
   (flight-ready? ..flight..) => falsey (provided (copilot-ready? ..flight..) => false)
@@ -50,18 +50,18 @@
 
 (fact "prerequisites can be nested"
   (prerequisite (x-handler 1) => 8000)
-  (fact 
+  (fact
     (prerequisite (y-handler 1) => 80)
     (function-under-test 1 1) => 8080)
 
   (fact
     (prerequisite (y-handler 1) => -8000)
     (function-under-test 1 1) => 0))
-    
+
 (fact "prerequisites can be nested"
   (prerequisites (x-handler 1) => 10
                  (y-handler 1) => 8)
-  (fact 
+  (fact
     (prerequisite (y-handler 1) => 33)
 
     (function-under-test 1 1) => (+ 10 33)

--- a/test/as_documentation/prerequisites/streaming_with_exceptions.clj
+++ b/test/as_documentation/prerequisites/streaming_with_exceptions.clj
@@ -13,7 +13,7 @@
 ;; this function.
 (defn value-stream
   "Convert on-demand calls of a function into a lazy seq of values.
-   Note that the stream is assumed to be infinite - there is no 
+   Note that the stream is assumed to be infinite - there is no
    'out of values' indicator."
   [stream-fn]
   (cons (stream-fn) (lazy-seq (value-stream stream-fn))))
@@ -55,7 +55,7 @@
 ;; 3: Compose the two ideas.
 
 (defn sentinelized-stream
-  "Convert stream into a lazy sequence of values, with 
+  "Convert stream into a lazy sequence of values, with
    ::sentinel replacing any exceptions."
   [stream-fn]
   (value-stream #(value-or-sentinel stream-fn (constantly ::sentinel))))
@@ -71,7 +71,7 @@
     (provided
       (source-of-values-fn) =throws=> (new Exception))))
 
-;; Per J.B. Rainsberger, "test until fear turns to boredom". I'm confident that the above 
+;; Per J.B. Rainsberger, "test until fear turns to boredom". I'm confident that the above
 ;; will work for a mixture of real values and exceptions, but let's see!
 ;;
 ;; Note: my first thought was to construct a lazy stream like this:
@@ -85,7 +85,7 @@
 ;; never changes. So we have to resort to explicit state.
 
 (defn mkfn:fail-on [fail-set]
-  (let [count (atom 0)] 
+  (let [count (atom 0)]
     (fn []
       (let [retval (swap! count inc)]
         (if (fail-set retval)

--- a/test/as_documentation/prerequisites/used_with_protocols.clj
+++ b/test/as_documentation/prerequisites/used_with_protocols.clj
@@ -7,7 +7,7 @@
 
 (defprotocol Addable
   (add-fields [this]))
-    
+
 (defrecord MyRecord [a b]
   Addable
   (add-fields [this] (+ a b)))
@@ -30,7 +30,7 @@
 (note-that (failed 2 :times))
 (for-failure 1 (note-that (prerequisite-was-called-the-wrong-number-of-times #"add-fields anything" 0 :times)))
 (for-failure 2 (note-that (fact-actual "3") (fact-expected "faked!")))
-           
+
 
 ;; In order to override the default add-fields, we have to fake out the inlining. That's done with the
 ;; defrecord-openly form:
@@ -85,7 +85,7 @@
 
 ;;; Records and types can also implement methods from Java interfaces (and override
 ;;; methods of Object). However, those are still implemented as Java methods, so they
-;;; cannot be overridden with prerequisites. 
+;;; cannot be overridden with prerequisites.
 
 (defprotocol Fearful
   (fear? [this]))
@@ -138,7 +138,7 @@
   (provided
     (pzero? (Peano. ...zero...)) => true))
 
-(silent-fact 
+(silent-fact
  (padd (Peano. ...a...) (psuccessor (Peano. ...b...))) => (psuccessor (padd (Peano. ...a...) (Peano. ...b...)))
  (provided
    (pzero? anything) => true))

--- a/test/as_documentation/prerequisites/variant_arrows.clj
+++ b/test/as_documentation/prerequisites/variant_arrows.clj
@@ -3,12 +3,12 @@
             [midje.util :refer :all]
             [midje.test-util :refer :all]
             [midje.util.exceptions :refer :all]))
-  
+
 
 ;; A typical called/caller relationship. The key thing is that
 ;; the caller calls the called more than once.
 (defn number [] )
-(defn two-numbers [] 
+(defn two-numbers []
   (+ (number) (number)))
 
 

--- a/test/as_documentation/setup_and_teardown.clj
+++ b/test/as_documentation/setup_and_teardown.clj
@@ -13,7 +13,7 @@
 
   (fact "it also gets set before this fact"
     @state => 0))
-    
+
 ;;; It's common to put `with-state-changes` inside an outermost fact
 
 (facts swap!
@@ -44,7 +44,7 @@
 
                                         ;;; teardown
 
-;; Combining setup and teardown. 
+;; Combining setup and teardown.
 
 (fact "whereas `before` executes outer-to-inner, `after` is the reverse"
   (with-state-changes [(before :facts (reset! log ["outer in"]))
@@ -58,24 +58,24 @@
            "outer out"])
 
 (fact "teardown is executed even if the enclosed fact throws an exception."
-  (try 
+  (try
     (with-state-changes [(after :facts (reset! log ["caught!"]))]
       (fact
         (throw (new Error))))
   (catch Error ex))
   @log => ["caught!"])
-  
-    
+
+
 (fact "teardown is NOT executed when the corresponding `before` throws an exception."
   ;; Use `around` instead.
-  (try 
+  (try
     (with-state-changes [(before :facts (do (reset! log [])
                                             (throw (new Error))))
                          (after :facts (reset! log ["caught!"]))]
       (fact))
   (catch Error ex))
   @log =not=> ["caught!"])
-      
+
                                         ;;; namespace-state-changes
 
 ;;; The earlier example of testing `swap!` surrounded three facts with
@@ -95,7 +95,7 @@
   @state => 1)
 
 ;;; Note that any use of `namespace-state-changes` erases the
-;;; previous one. For example, the following doesn't add teardown to 
+;;; previous one. For example, the following doesn't add teardown to
 ;;; the earlier setup. There is no longer any setup, just teardown.
 
 (namespace-state-changes [(after :facts (swap! state inc))])

--- a/test/as_documentation/sketch_for_background_replacement.clj
+++ b/test/as_documentation/sketch_for_background_replacement.clj
@@ -19,7 +19,7 @@
 ;;                           (ping 'symbol) => 404)
 ;;     (f 3) => 5
 ;;     (provided ...))
-    
+
 ;;   (prerequisite-group [(only-numberish-values-succeed?) => true]
 ;;     (ping 1) => 200
 ;;     (ping "1") => 200
@@ -29,13 +29,13 @@
 ;;     (assume-prerequisite (only-numberish-values-succeed?) => true)
 ;;     ...)
 
-  
+
 
 ;;   (prerequisite-group [(numberish-value-status) => ?desired-status]
 ;;     (ping 1) => ?desired-status
 ;;     (ping "1") => ?desired-status
 ;;     (ping 'symbol) => 404)
-  
+
 ;;   (fact "text"
 ;;     (assume-prerequisite (numberish-value-status) => 200)
 ;;     ...)
@@ -65,15 +65,15 @@
 ;;     (dotimes [n ?number]
 ;;       (create-animal :species ?species
 ;;                      :name  (str "horse-" n))))
-    
-                         
+
+
 
 ;;   (to-ensure [(horses
-  
+
 ;;   (to-ensure [@log => empty?]
 ;;     (reset! log []))
 
-;;   (fact 
+;;   (fact
 ;;     (ensure-prerequisite @log => empty?)
 ;;   ;; Empty the log before every example
 ;;   )
@@ -101,9 +101,9 @@
 ;;     (fact "another subclaim")
 ;;       (assume-prerequisite (inner 1) => "55555555555555555555")
 ;;       ;; examples here see both prerequisites, but note that
-;;       ;; `(inner 1)` returns a different value. 
+;;       ;; `(inner 1)` returns a different value.
 ;;       )
-    
+
 ;; )
 
 ;; (fact "you can insert into the database"
@@ -114,5 +114,5 @@
 ;;     (count matches) => 1
 ;;     (:greeting match) => "hi"
 ;;     (:person match) => "mom!"))
-  
+
 ;; )

--- a/test/as_documentation/tabular_facts.clj
+++ b/test/as_documentation/tabular_facts.clj
@@ -46,7 +46,7 @@
 ;;; If you prefer, you can put the doc string on the enclosed fact rather than the
 ;;; tabular fact:
 
-(tabular 
+(tabular
   (fact "Put the doc string wherever you prefer"
     (+ ?a ?b) => ?result )
   ?a    ?b      ?result
@@ -66,7 +66,7 @@
   (let [marked-facts (fetch-facts *ns* :a-tabular-fact)]
     (count marked-facts) => 1
     (:a-tabular-fact (meta (first marked-facts))) => true))
-    
+
 
 ;;;                                     Miscellany
 

--- a/test/behaviors/background_nesting/t_exception.clj
+++ b/test/behaviors/background_nesting/t_exception.clj
@@ -5,9 +5,9 @@
 ;; This is a separate file because we're making namespace-wide changes
 
 (unfinished outermost middlemost innermost)
-  
+
 (against-background [ (middlemost) => "FOO!" ]
-  (try 
+  (try
     (against-background [ (middlemost) => 33 ]
       (fact (middlemost) => 33)
       (throw (Throwable.)))

--- a/test/behaviors/background_nesting/t_left_to_right.clj
+++ b/test/behaviors/background_nesting/t_left_to_right.clj
@@ -6,7 +6,7 @@
 ;; This is a separate file because we're making namespace-wide changes
 
 (unfinished outermost middlemost innermost)
-      
+
 (deftest left-to-right-shadowing        ; deftest intentional
   (against-background [ (middlemost) => 33 (middlemost) => 12]
     (fact (* 2 (middlemost)) => 24)))

--- a/test/behaviors/background_nesting/t_shadowing.clj
+++ b/test/behaviors/background_nesting/t_shadowing.clj
@@ -14,4 +14,4 @@
               (middlemost) => 'a)
   (against-background [ (middlemost) => 33]
     (fact (+ (middlemost) (outermost)) => 35)))
-  
+

--- a/test/behaviors/background_nesting/t_shadowing_outside_background.clj
+++ b/test/behaviors/background_nesting/t_shadowing_outside_background.clj
@@ -13,7 +13,7 @@
 (deftest background-command-is-shadowed-by-against-background   ; deftest intentional
   (against-background [ (middlemost) => 33]
     (fact (+ (middlemost) (outermost)) => 35)))
-  
+
 (against-background [ (middlemost) => 33]
   (fact (+ (middlemost) (outermost)) => 35))
-  
+

--- a/test/behaviors/background_nesting/t_three_levels_outside.clj
+++ b/test/behaviors/background_nesting/t_three_levels_outside.clj
@@ -22,7 +22,7 @@
 
 (against-background [ (middlemost 2) => 33
                       (innermost) => 'c]
-  
+
   (against-background [ (middlemost 1) => -43 ]
     (fact
       (against-background (innermost) => 8)

--- a/test/behaviors/t_canary.clj
+++ b/test/behaviors/t_canary.clj
@@ -18,7 +18,7 @@
      (favorite-animal-name) => "betsy"
      (provided
        (name (favorite-animal)) => "betsy"))
-			  
+
 
 
 
@@ -45,14 +45,14 @@
 (tabular
   (fact "makes a stream of given day of the month"
     (day-of-month-stream 1) => ?date-time)
-	  
+
 	?nth   ?date-time
         first  (new-date 1 2 3))
 
 (defn today-num [])
 
-(tabular 
- (fact 
+(tabular
+ (fact
    #(today-num) => anything)
  ?day-num
  7 )

--- a/test/behaviors/t_default_prerequisites.clj
+++ b/test/behaviors/t_default_prerequisites.clj
@@ -7,5 +7,5 @@
 (unfinished unused)
 
 (against-background [(unused 3) => 4]
-  (fact 
+  (fact
     (calls-nothing) => nil))

--- a/test/behaviors/t_formulas.clj
+++ b/test/behaviors/t_formulas.clj
@@ -13,7 +13,7 @@
 (defn- gen-int [pred]
   (rand-nth (filter pred [-999 -100 -20 -5 -4 -3 -2 -1 0 1 2 3 4 5 20 100 999])))
 
-;; Formulas are a generative style test macro. Each binding has a generator on 
+;; Formulas are a generative style test macro. Each binding has a generator on
 ;; the right and a symbol on the left that will hold the generated value
 
 (formula "can now use simple generative-style formulas - with multiple bindings"
@@ -27,7 +27,7 @@
 (formula "'provided' works"
   [a (make-string)]
   (g a) => (str "foo" a)
-  (provided 
+  (provided
     (f anything) => "foo"))
 
 
@@ -36,7 +36,7 @@
 (silent-formula "some description" [a "y"] a => :foo)
 (note-that (fails 1 time))
 
-;; Passing formulas run the generator many times, and evaluate 
+;; Passing formulas run the generator many times, and evaluate
 ;; their body many times - number of trials is rebindable
 (defn-call-countable y-maker [] "y")
 (defn-call-countable my-str [s] (str s))
@@ -50,7 +50,7 @@
 
 ;; There is syntactic sugar for binding *num-trials*
 (defn-call-countable k-maker [] "k")
-(with-num-trials 1000 
+(with-num-trials 1000
   (formula [a 1] (k-maker) => "k")
   (formula [a 1] (k-maker) => "k")
   (formula [a 1] (k-maker) => "k"))
@@ -81,11 +81,11 @@
 (future-formula "demonstrating the ability to create future formulas"
   [a 1]
   a => 1)
-                
+
 
 ;;;; Validation
 
-;; The following factsexpress an assortment of ways that formulas 
+;; The following factsexpress an assortment of ways that formulas
 ;; could be expressed with invalid syntax
 
 (unfinished h)
@@ -95,24 +95,24 @@
   (silent-formula [a 1] 1)
   (silent-formula "a doc string" [a 1] (contains 3))
 
-  (silent-formula "ignores arrows in provideds" [a 1] 
+  (silent-formula "ignores arrows in provideds" [a 1]
     (contains 3)
     (provided (h anything) => 5))
 
-  (silent-formula "ignores arrows in against-background" [a 1] 
+  (silent-formula "ignores arrows in against-background" [a 1]
     (contains 3)
     (against-background (h anything) => 5))
 
-  (silent-formula "ignores arrows in against-background - even when it comes first" 
+  (silent-formula "ignores arrows in against-background - even when it comes first"
     [a 1]
     (against-background (h anything) => 5)
     (contains 3))
 
-  (silent-formula "ignores arrows in background" [a 1] 
+  (silent-formula "ignores arrows in background" [a 1]
     (contains 3)
     (background (h anything) => 5))
 
-  (silent-formula "ignores arrows in background - even when it comes first" 
+  (silent-formula "ignores arrows in background - even when it comes first"
     [a 1]
     (background (h anything) => 5)
     (contains 3))
@@ -125,7 +125,7 @@
   (silent-formula "a doc string" [] 1 => 1)
   (silent-formula "a doc string" {:num-trials 50} 1 => 1)
   (for-each-failure (note-that parse-error-found, (fact-failed-with-note error-regexp))))
-  
+
 (silent-formula "a doc string" [a 1] a => 1 a => 1)
 (note-that parse-error-found, (fact-failed-with-note #"There are too many expections in your formula form"))
 
@@ -166,13 +166,13 @@
 (formula
   "binding too small a value - gives nice error msg"
   [n (gen-int #(< % 1))]
-  (binding [*num-trials* n] nil) 
+  (binding [*num-trials* n] nil)
      => (throws #"must be an integer 1 or greater"))
 
 (formula
   "allows users to dynamically rebind to 1+"
   [n (gen-int #(>= % 1))]
-  (binding [*num-trials* n] nil) 
+  (binding [*num-trials* n] nil)
      =not=> (throws Exception))
 
 

--- a/test/behaviors/t_metaconstant_compilation.clj
+++ b/test/behaviors/t_metaconstant_compilation.clj
@@ -2,11 +2,11 @@
   (:require [midje.sweet :refer :all]))
 
 ;;; Because metaconstants are auto-defined, a file without `metaconstants`
-;;; will fail AOT compilation. 
+;;; will fail AOT compilation.
 
-(metaconstants ..m.. ..m.... .mc.)    
+(metaconstants ..m.. ..m.... .mc.)
 
-(fact "printing" 
+(fact "printing"
   (str .mc.) => ".mc."
   (pr-str .mc.) => ".mc.")
 

--- a/test/behaviors/t_setup_teardown.clj
+++ b/test/behaviors/t_setup_teardown.clj
@@ -7,13 +7,13 @@
  (against-background (before :checks (swap! test-atom (constantly 0))))
  (swap! test-atom inc) => 1
  (swap! test-atom dec) => -1)
-    
+
 (def test-atom (atom 0))
 (against-background [ (after :checks (swap! test-atom (constantly 0))) ]
   (fact
     (swap! test-atom inc) => 1
     (swap! test-atom dec) => -1))
-    
+
 (def before-atom (atom 10))
 (def after-atom (atom 33))
 (fact
@@ -24,7 +24,7 @@
   ;; [1 10]
   [(swap! before-atom inc) (swap! after-atom inc)] => [1 11]
   ;; [1 10]
-  
+
   (let [untouched [@before-atom @after-atom]]
     untouched => [1 10]))
 
@@ -110,7 +110,7 @@
   (fact "one set of facts"
     (against-background (before :checks (swap! per-check-atom (constantly 3))
                                 :after (swap! per-check-atom (constantly 888))))
-      
+
     @immediate-atom => 33  ;; content wrapper applies
     @per-fact-atom => 18   ;; fact wrapper applies
     @per-check-atom => 3   ;; per-check wrapper applies
@@ -122,7 +122,7 @@
     (swap! per-check-atom inc) => 4   ;; See?
 
     (+ (f ...arg...) x) => 301)
-  
+
   (fact "the other"
     @immediate-atom => 34       ;; immediate wrapper doesn't apply.
     @per-fact-atom => 18        ;; per-fact wrapper resets.
@@ -174,4 +174,4 @@
                                                 a (* 4 y)] ?form)))
       (+ x y z a) => 14)))
 
-  
+

--- a/test/behaviors/t_unfinished.clj
+++ b/test/behaviors/t_unfinished.clj
@@ -12,4 +12,4 @@
   (backing-function 2 "string") => (throws Error
                                            #"no implementation"
                                            #"\(backing-function 2 \"string\"\)"))
-  
+

--- a/test/implementation/checking/checkers/fim_collection_diffs.clj
+++ b/test/implementation/checking/checkers/fim_collection_diffs.clj
@@ -15,12 +15,12 @@
   (subject/classify {} (R.) #{}) => :map:map
   (subject/classify (R.) {} #{:gaps-ok :in-any-order}) => :map:map
   (subject/classify (R.) (R.) #{}) => :map:map
-  
+
   (subject/classify :other :things #{}) => :unknown)
 
 
 
-            
+
 
 ;; Eventually, the `differ` will be the actual checker, making this format a bit more
 ;; readable.

--- a/test/implementation/checking/fim_facts.clj
+++ b/test/implementation/checking/fim_facts.clj
@@ -27,7 +27,7 @@
       (with-record
         (subject/check-one (top-level true faux-fact))
         @record => "called"))
-    
+
     (fact "running a fact that matches a fact filter"
       (with-filter [:filt]
         (subject/check-one (tagged :filt (top-level true faux-fact)))
@@ -48,7 +48,7 @@
       (with-record
         (subject/check-one (top-level false faux-fact))
         @record => "called"))
-    
+
     (fact "running a fact without metadata in context of filter: *called*"
       ;; Called because if the filter mattered, this function would never be called.
       (with-filter [:filt]

--- a/test/implementation/emission/plugins/fim_flare.clj
+++ b/test/implementation/emission/plugins/fim_flare.clj
@@ -85,7 +85,7 @@
        '[a b        ] )
     => ["At index 1, got `[Z z zz] instead of `b`"])
 
-  (future-fact "Actual has extra elements" 
+  (future-fact "Actual has extra elements"
     (f '[a b c d e]
        '[a b      ])
     => [  "Actual has 3 extra elements `(c d e)`"])
@@ -120,7 +120,7 @@
      "At path [1 1], got `Z` instead of `2`."
      "At index 4, missing key `:b`"])
 
-  (future-fact 
+  (future-fact
     (f '[0 {1 [2 Z], 2 3} [Z] [3 {:a Z}]]
        '[0 {1 [2 2], 2 4} [3] [3 {:a 2}]])
     => ["At path [1 1 0], got `Z` instead of `2`"

--- a/test/implementation/fim_open_protocols.clj
+++ b/test/implementation/fim_open_protocols.clj
@@ -33,7 +33,7 @@
       (macroexpand-1 in-rec) => unexpanded-out-rec
     (finally
      (alter-var-root #'midje.sweet/include-midje-checks (constantly true))))))
-      
+
 
 
 

--- a/test/implementation/line_numbers/fim_check_failures.clj
+++ b/test/implementation/line_numbers/fim_check_failures.clj
@@ -15,11 +15,11 @@
 
 (def simple-start 16)
 
-(silent-fact (+ 1 1) => 3) 
+(silent-fact (+ 1 1) => 3)
 (note-that (failure-was-at-line (+ simple-start 2)))
 
 (silent-fact "odd positioning"
-   
+
     (+ 1 1) =>   ; here
 
     3)
@@ -30,7 +30,7 @@
 (note-that (failure-was-at-line (+ simple-start 13)))
 
 (silent-fact (g 1) => 1
-  
+
   ;; quite the gap.
 
   (provided
@@ -64,15 +64,15 @@
              (prerequisite-was-never-called #"favorite-animal")
              (fact-expected "betsy")
              (failures-were-at-lines  (+ deftest-start 11) (+ deftest-start 11) (+ deftest-start 9)))
-  ;; Three things tested here. (1) there is a single composite "never-called" failure that 
+  ;; Three things tested here. (1) there is a single composite "never-called" failure that
   ;; (2) has the position of the first of it's elements. Moreover, (3) the prerequisite failure
   ;; comes before the bad actual value.
   (for-failure 1 (note-that (failure-was-at-line (+ deftest-start 11))))
   (for-failure 2 (note-that (fact-expected "betsy")
                             (failure-was-at-line (+ deftest-start 9))))
-             
 
-  
+
+
   (silent-fact
    (favorite-animal-only-animal) => "betsy"  ;; here
    (provided
@@ -120,7 +120,7 @@
 (config/with-augmented-config {:visible-future true}
   (capturing-fact-output
    (fact "text"
-     
+
      (+ 1 "1") =future=> "2")
    (fact @fact-output => #"fim_check_failures.*124")))
 
@@ -141,10 +141,10 @@
 (note-that (failure-was-at-line (+ patho-start 7)))
 
 (silent-fact "Facts that have detectable line numbers update the best-guess."
-   
+
    (+ 1 2) => odd?  ;; best guess is now here
    1 => even?)      ;; so this is correctly reported
-(note-that (failure-was-at-line (+ patho-start 14))) 
+(note-that (failure-was-at-line (+ patho-start 14)))
 
 (silent-fact "each emission, even if wrong, is taken as best guess for future"
    1 => even?  ;; This is correctly guessed.
@@ -180,7 +180,7 @@
   (silent-fact (inc ?n) => ?n)
 
 
-  
+
   ?n  ?comment
   1   "1")
 (note-that (failure-was-at-line (+ tabular-line 2)))

--- a/test/implementation/parsing/1_to_explicit_form/fim_metadata.clj
+++ b/test/implementation/parsing/1_to_explicit_form/fim_metadata.clj
@@ -8,7 +8,7 @@
 (def a-body '((f) => 3))
 (def body-guid (random/form-hash a-body))
 
-(facts "about separate-metadata" 
+(facts "about separate-metadata"
   (fact "contains the original source and other info, appropriately quoted"
     (let [[meta _] (separate-metadata `(fact "doc" ~@a-body))]
       (:midje/source meta) => `'(fact "doc" ~@a-body)
@@ -30,7 +30,7 @@
 
         (fact "and can be unparsed"
           (unparse-metadata meta) => (just "doc"))))
-    
+
     (fact "need not be present"
       (let [[meta body] (separate-metadata `(fact ~@a-body))]
         (:midje/description meta) => nil
@@ -38,7 +38,7 @@
 
         (fact "and can be unparsed"
           (unparse-metadata meta) => empty?)))
-      
+
     (fact "can provide the name"
       (let [[meta body] (separate-metadata `(fact "doc" ~@a-body))]
         (:midje/name meta) => "doc"
@@ -46,7 +46,7 @@
 
         (fact "and can be unparsed"
           (unparse-metadata meta) => (just "doc")))))
-  
+
   (facts "symbols"
     (fact "become the fact name"
       (let [[meta body] (separate-metadata `(fact cons ~@a-body))]
@@ -63,12 +63,12 @@
 
         (fact "and, when seen with a doc string, parses back into both originals"
           (unparse-metadata meta) => (just ['cons "foo"] :in-any-order)))
-        
+
       (let [[meta body] (separate-metadata `(fact cons "foo" ~@a-body))]
         (:midje/name meta) => "cons"
         body => a-body
         (unparse-metadata meta) => (just ['cons "foo"] :in-any-order)))
-    
+
     (fact "don't count as names when they are the head of an expect form"
       (let [[meta body] (separate-metadata `(fact foo => 3))]
         (:midje/name meta) => nil
@@ -105,28 +105,28 @@
   (fact "is not confused by the presence of an arrow form"
     (let [[meta form] (separate-metadata `(fact 112 => 211))]
       form => `(112 => 211))
-    
+
     (let [[meta form] (separate-metadata `(fact cons => cons))]
       (:midje/name meta) => nil
       form => `(cons => cons))
-    
+
     (let [[meta form] (separate-metadata `(fact :a => :b))]
       (:a meta) => nil
       form => `(:a => :b))
-    
+
     (let [[meta form] (separate-metadata `(fact {:a 1} => :b))]
       (:a meta) => nil
       form => `({:a 1} => :b))
-    
+
     (let [[meta form] (separate-metadata `(fact "foo" => 1))]
       (:midje/description meta) => nil
       form => `("foo" => 1))
-    
+
     (let [[meta form] (separate-metadata `(fact "name" "foo" => 1))]
       (:midje/name meta) => "name"
       (:midje/description meta) => "name"
       form => `("foo" => 1))
-    
+
     (let [[meta form] (separate-metadata `(fact foo "bar" => 1))]
       (:midje/name meta) => "foo"
       form => `("bar" => 1))))

--- a/test/implementation/parsing/1_to_explicit_form/fim_parse_background.clj
+++ b/test/implementation/parsing/1_to_explicit_form/fim_parse_background.clj
@@ -25,7 +25,7 @@
 
  [ (against-background ..back1..)
    ..body1..
-   (against-background ..back2..)]      [..back1.. ..back2..]           [..body1..] 
+   (against-background ..back2..)]      [..back1.. ..back2..]           [..body1..]
 
  []                                     []                              []
  [ (f 1) => 3 ]                         []                              [ (f 1) => 3 ]
@@ -72,7 +72,7 @@
 (fact "Collections of background changers are syntactically ornate, but they can be separated"
   (fact "ordinary prerequisites are converted to fakes"
     (separate-individual-changers []) => []
-    (separate-individual-changers `[(f 1) => 2]) 
+    (separate-individual-changers `[(f 1) => 2])
     => `[(fake (f 1) => 2 :background :background
                           :times (range 0))]
     (separate-individual-changers `[   (f 1) => 2 :foo 'bar (f 2) => 33 ])
@@ -112,15 +112,15 @@
     (let [template (make-state-unification-template '(before :checks (do-something)))]
       template => (form-matching? '(try (do-something) ?the-unification-symbol (finally nil)))
       template => (for-wrapping-target? :checks))
-  
+
     (let [template (make-state-unification-template '(before :facts (do-something) :after (finish)))]
       template => (form-matching? '(try (do-something) ?the-unification-symbol (finally (finish))))
       template => (for-wrapping-target? :facts))
-  
+
     (let [template (make-state-unification-template '(after :all (do-something)))]
       template => (form-matching? '(try ?the-unification-symbol (finally (do-something))))
       template => (for-wrapping-target? :all))
-  
+
     (let [template (make-state-unification-template '(around :checks (let [x 1] ?form)))]
       template => (form-matching? '(let [x 1] ?the-unification-symbol))
       template => (for-wrapping-target? :checks)))

--- a/test/implementation/parsing/util/fim_exception_line_numbers.clj
+++ b/test/implementation/parsing/util/fim_exception_line_numbers.clj
@@ -11,7 +11,7 @@
  (fact
    @fact-output => #"Midje caught an exception when translating this form"
    @fact-output => #"fim_exception_line_numbers.clj:10"))
-   
+
 
 (capturing-failure-output ;; Reports on outer-level fact
  (macroexpand '(fact "fine" (fact "description" (+ 1 1) =throw-parse-exception=> 2)))

--- a/test/implementation/parsing/util/fim_recognizing.clj
+++ b/test/implementation/parsing/util/fim_recognizing.clj
@@ -5,9 +5,9 @@
             [midje.parsing.util.recognizing :refer :all]
             [clojure.zip :as zip]))
 
-;;; Arrows 
+;;; Arrows
 
-(tabular 
+(tabular
  (fact "an embedded expect form can be recognized"
    (expect? (zip/seq-zip ?form)) => ?expected)
 
@@ -31,10 +31,10 @@
   (let [possible (fn [nested-form] (zip/down (zip/seq-zip nested-form)))]
               "a string" =not=> start-of-checking-arrow-sequence?
               '(foo) =not=> start-of-checking-arrow-sequence?
-    
+
               '( (f 1) ) =not=> start-of-checking-arrow-sequence?
     (possible '( (f 1) )) =not=> start-of-checking-arrow-sequence?
-    
+
               '( (f 1) (f 2)) =not=> start-of-checking-arrow-sequence?
     (possible '( (f 1) (f 2))) =not=> start-of-checking-arrow-sequence?
 

--- a/test/implementation/prerequisites/fim_call_counts.clj
+++ b/test/implementation/prerequisites/fim_call_counts.clj
@@ -16,14 +16,14 @@
   :fake          0               :default                TRUTHY
   :fake          1               :default                falsey
   :fake          200             :default                falsey
-  
+
   :fake          2              (range 0 2)              TRUTHY
   :fake          1              (range 0 2)              falsey
   :fake          1              #{0 2}                   TRUTHY
-  
+
   :fake          1              2                        TRUTHY
   :fake          1              1                        falsey
-  
+
   :fake          1               even?                   TRUTHY
   :fake          2               even?                   falsey)
 

--- a/test/midje/checking/checkers/t_chatty.clj
+++ b/test/midje/checking/checkers/t_chatty.clj
@@ -12,14 +12,14 @@
 (facts "about chatty-checking utility functions"
 
   (chatty-untease 'g-101 '()) => [[] []]
-  
+
   (chatty-untease 'g-101 '(1 (f) 33 (+ 1 2))) =>
                 [ '( (f) (+ 1 2))  '(1 (g-101 0) 33 (g-101 1))  ])
 
-(tabular 
+(tabular
   (fact "knows if is worth reporting on"
     (chatty-worth-reporting-on? ?arg) => ?worth-it)
-  
+
     ?arg   ?worth-it
     1      falsey
     '()    falsey
@@ -46,7 +46,7 @@
 
 
 
-  
+
 ;; The form of chatty checkers
 
 (def actual-plus-one-equals-4 (chatty-checker [actual] (= (inc actual) 4)))
@@ -61,7 +61,7 @@
 
 (facts "about what chatty-checkers return"
   (actual-plus-one-equals-4 3) => true
-   
+
   (let [result (actual-plus-one-equals-4 4)]
     result => data-laden-falsehood?
     result => {:actual 4
@@ -102,23 +102,23 @@
   (= (vec-structured-checker [1 2 3 4]) true) => truthy )
 
 (tabular "chatty checkers can use a map destructuring argument"
-  (fact 
+  (fact
       (= (?structured-checker {:a 1 :b 2}) true) => truthy
       (= (?structured-checker {:a 10 :b 10}) true) => falsey)
-  
+
   ?structured-checker
   map-structured-checker
   map-structured-checker-with-as
   other-map-structured-checker )
 
-(tabular 
+(tabular
   (fact "different parts are in fact checked"
     (let [result (vec-structured-checker ?actual)]
       (= result true) => falsey
       (:actual result) => ?actual))
-  ?actual       
-  ['x 2 3 4]    
-  [1 'x 3 4]    
+  ?actual
+  ['x 2 3 4]
+  [1 'x 3 4]
   [1 2 3 4 'x])
 
 (fact "folded results are still shown"
@@ -129,15 +129,15 @@
 
 (tabular "map structured checkers still work"
   (fact (:intermediate-results (?structured-checker {:a 10 :b 2}))
-  => '(    ((= a 1) false) 
+  => '(    ((= a 1) false)
            ((= b 2) true) ))
-  
+
   ?structured-checker
   map-structured-checker
   map-structured-checker-with-as
   other-map-structured-checker )
 
-  
+
 ;; Chatty checkers: interaction with checkers that return chatty-failures.
 (defn rows-in [rows] rows)
 (defn has-rows [rows]
@@ -153,7 +153,7 @@
 
 
 ;; Old bug. During midjcoexpansion/macroexpansion, the interior of a chatty checker
-;; can turn into a lazy seq, which should be treated as if it were a list. This checks that. 
+;; can turn into a lazy seq, which should be treated as if it were a list. This checks that.
 (silent-fact
  (let [a-chatty-checker (fn [expected]
                           (chatty-checker [actual] (= expected (+ 1 actual))))]
@@ -177,4 +177,4 @@
 
 
 
-  
+

--- a/test/midje/checking/checkers/t_collection.clj
+++ b/test/midje/checking/checkers/t_collection.clj
@@ -22,7 +22,7 @@
   [0 3 'a 1 2] => (contains #(<= % 3) #(<= % 2) #(<= % 1) :in-any-order :gaps-ok)
   [0 2 3 'a 1] => (contains #(<= % 3) #(<= % 2) #(<= % 1) :in-any-order :gaps-ok))
 
-  
+
 
 (fact "left-hand-side: sequentials that are to contain things"
   [3 4 5 700]        => (contains [4 5 700])
@@ -35,7 +35,7 @@
   [4 5 'hi 700]      => (contains [4 5 700] :gaps-ok)
   [4 700 'hi 5] =deny=> (contains [4 5 700] :gaps-ok)
 
-  
+
   [4 700 5] => (contains [4 5 700] :gaps-ok :in-any-order)
   [4 5 'hi 700] => (contains [4 5 700] :in-any-order :gaps-ok)
   [700 'hi 4 5 'hi] => (contains [4 5 700] :in-any-order :gaps-ok)
@@ -54,9 +54,9 @@
   ( (contains [(AB. 1 2)]) [ [:a 1] [:b 2 ] ] ) => falsey
 
   ;; Just
-  [1 2 3] => (just [1 2 3]) 
-  ( (just [1 2 3 4]) [1 2 3]) => falsey 
-  ( (just [1 2 3]) [1 2 3 4]) => falsey 
+  [1 2 3] => (just [1 2 3])
+  ( (just [1 2 3 4]) [1 2 3]) => falsey
+  ( (just [1 2 3]) [1 2 3 4]) => falsey
 
   [1 2 3] => (just [odd? even? odd?])
 
@@ -108,7 +108,7 @@
   ( (has every? (chatty-checker [actual] (and (map? actual)
                                               (odd? (:x actual)))))
     [{:x 4}]) => falsey
-         
+
 
   ;; More than one not enclosed in a collection
   [700 4 5] => (just 4 5 700 :in-any-order)
@@ -125,20 +125,20 @@
 (fact "left-hand-side: actual return values that are strings"
   "abc" => (contains "bc")
   ( (contains "bc") "bd") => falsey
-  
-  "abc" => (contains "ac" :gaps-ok) 
+
+  "abc" => (contains "ac" :gaps-ok)
   "abc" => (contains "ba" :in-any-order)
 
   "abc" => (just "abc")
   ( (just "ab") "abc") => falsey
-  
+
   ( (just "ac" :gaps-ok) "abc") => falsey
   "abc" => (just "cba" :in-any-order)
   ( (just "cba" :in-any-order) "ab") => falsey
   ( (just "cba" :in-any-order) "abcd") => falsey
 
-  "abc" => (has-suffix "bc") 
-  "abc" => (has-prefix "ab") 
+  "abc" => (has-suffix "bc")
+  "abc" => (has-prefix "ab")
   ( (has-suffix "ac") "abc") => falsey
   ( (has-suffix "ap") "abc") => falsey
 
@@ -148,7 +148,7 @@
   ;; Comparisons to regular expressions
   "  1" => #"\d"
 
-  "  3" => (contains #"\d")  
+  "  3" => (contains #"\d")
   ( (contains #"\d") "   ") => falsey
 
   "123" => (just #"\d\d\d")
@@ -220,7 +220,7 @@
 
   ( (just "ab") "AB") => falsey
   "AB" => #"(?i)ab"
-  
+
   ;; Just to check
   ( (contains "a") [1]) => falsey
   ( (contains #"a") [1]) => falsey
@@ -235,7 +235,7 @@
 (fact "left-hand-side: sets to contain things"
   #{1 2 3} => (contains #{1 2 3})
   #{1 2 3} => (contains [1 2 3])
-                        
+
   #{"1" "12" "123"} => (contains [#"1" #"2" #"3"])
   #{"1" "12" "123"} => (contains [#"1" #"2" #"3"])
   #{"1" "12" "123"} => (contains #{#"1" #"2"})
@@ -298,7 +298,7 @@
  ;; ... this requires it:
  {:expected-found [#"2" #"1" #"3"] }
  => (contains {:expected-found (just [#"2" #"1" #"3"]) })
- 
+
  {} => (contains {})
  {nil nil} => (contains {})
  {nil nil} => (contains {nil nil})
@@ -367,8 +367,8 @@
   (AB. 1 2) => (just [[:a 1] [:b 2]])
   (AB. 1 2) => (just [:a 1] [:b 2])
   (AB. 1 2) => (contains [[:a 1]]))
- 
-  
+
+
 
 (facts "where actual values are of wrong type for legitimate expected"
 
@@ -413,7 +413,7 @@
 
   ; It'd be nice to make all kinds of recursive function printing work nicely.
   ; [odd? even?] => (contains [(exactly odd?) (exactly odd?)])
-  
+
   "checkers are printed nicely in the expected matched: section"
   (data-laden-falsehood-to-map ( (contains [5 (exactly 4)] :in-any-order) [1 2 4]))
   => (contains {:notes (contains #"It matched.*\[\(exactly 4\)\]")})
@@ -484,12 +484,12 @@
 (facts "n-of functions"
   (fact "pass w/ correct # of matching results"
     [33 33 ] => (two-of 33)
-    
+
     [1 3 ] => (n-of odd? 2)
     ["ab" "aab" "aaab"] => (n-of #"a+b" 3)
     ( (n-of odd? 1) [1 3]) => data-laden-falsehood?
     ( (n-of odd? 3) [1 2 3]) => data-laden-falsehood?
-  
+
     [1 1 3 3 5 5 7 7 9 9] => (ten-of odd?)
     [1 1 3 3 5 5 7 7 9] => (nine-of odd?)
     [1 1 3 3 5 5 7 7] => (eight-of odd?)
@@ -500,15 +500,15 @@
     [1 1 3] => (three-of odd?)
     [1 1] => (two-of odd?)
     [1] => (one-of odd?))
-  
+
   (fact "fail w/ wrong # of matching results"
     [33 33 22] =not=> (two-of 33)
-    
+
     [1 3 2] =not=> (n-of odd? 2)
     ["ab" "aab" "aaab" "ccc"] =not=> (n-of #"a+b" 3)
     ( (n-of odd? 1) [1]) =not=> data-laden-falsehood?
     ( (n-of odd? 3) [1 3 5]) =not=> data-laden-falsehood?
-  
+
     [1 1 3 3 5 5 7 7 9 9 11] =not=> (ten-of odd?)
     [1 1 3 3 5 5 7 7 9 9] =not=> (nine-of odd?)
     [1 1 3 3 5 5 7 7 9] =not=> (eight-of odd?)

--- a/test/midje/checking/checkers/t_collection_old.clj
+++ b/test/midje/checking/checkers/t_collection_old.clj
@@ -9,8 +9,8 @@
 (facts "about has-prefix"
   "lists"
   '() => (has-prefix '())
-  '(1) => (has-prefix '()) 
-  '(1) => (has-prefix '(1)) 
+  '(1) => (has-prefix '())
+  '(1) => (has-prefix '(1))
   '(1 2 3) => (has-prefix '(1))
   ((has-prefix '(2)) '(1 2 3)) => falsey
   '(1 2 3) => (has-prefix '(1 2))
@@ -58,7 +58,7 @@
 
   [ {:a 1} "irrelevant"] => (has-prefix   {:a 1})
 
-  ( (has-prefix [ {:a 1} ])  [ {:a 1, :b 1} ]) => falsey  
+  ( (has-prefix [ {:a 1} ])  [ {:a 1, :b 1} ]) => falsey
   ( (has-prefix {:a 1}) [ {:a 2} ]) => falsey
   ( (has-prefix {:a 1}) [ 1 2 3 ]) => falsey
   ( (has-prefix {:a 1}) [ [:a 1] ]) => falsey ; I suppose could arguably be true.
@@ -103,7 +103,7 @@
   [nil "foo"] => (has-prefix nil)
 
   ( (has-prefix [nil]) []) => falsey
-  
+
   "individual elements"
   [1 2 3] => (has-prefix 1)
   [1 2 3] => (has-prefix odd?)
@@ -113,8 +113,8 @@
 (facts "about has-prefix where elements can be in any order"
   "lists"
   '() => (has-prefix '() :in-any-order)
-  '(1) => (has-prefix '() :in-any-order) 
-  '(1) => (has-prefix '(1) :in-any-order) 
+  '(1) => (has-prefix '() :in-any-order)
+  '(1) => (has-prefix '(1) :in-any-order)
   '(1 2 3) => (has-prefix '(1) :in-any-order)
   ((has-prefix '(2) :in-any-order) '(1 2 3)) => falsey
   '(1 2 3) => (has-prefix '(1 2) :in-any-order)
@@ -149,7 +149,7 @@
   ( (has-prefix #{2 1 5} :in-any-order) [1 2 3]) => falsey
 
   "maps"
-  ((has-prefix :a :in-any-order) { :a 1 }) 
+  ((has-prefix :a :in-any-order) { :a 1 })
   => (contains {:actual {:a 1} :notes (just "Maps don't have prefixes.")})
   ((has-prefix :a :in-any-order) [{ :a 1 }]) => falsey
   ((has-prefix [:a] :in-any-order) {:a 1 })
@@ -163,7 +163,7 @@
   [ {:a 1} {:b 1} {:c 1}] => (has-prefix [ {:b 1} {:a 1} ] :in-any-order)
   [ {:a 1} "irrelevant" ] => (has-prefix   {:a 1} :in-any-order)
 
-  ( (has-prefix [ {:a 1} ] :in-any-order)  [ {:a 1, :b 1} ]) => falsey  
+  ( (has-prefix [ {:a 1} ] :in-any-order)  [ {:a 1, :b 1} ]) => falsey
   ( (has-prefix {:a 1} :in-any-order) [ {:a 2} ]) => falsey
   ( (has-prefix {:a 1} :in-any-order) [ 1 2 3 ]) => falsey
   ( (has-prefix {:a 1} :in-any-order) [ [:a 1] ]) => falsey ; I suppose could arguably be true.
@@ -199,7 +199,7 @@
   [nil "foo"] => (has-prefix ["foo" nil] :in-any-order)
 
   ( (has-prefix [nil] :in-any-order) []) => falsey
-  
+
   "individual elements"
   [1 2 3] => (has-prefix 1 :in-any-order)
   [1 2 3] => (has-prefix odd? :in-any-order)
@@ -220,8 +220,8 @@
 
   "lists"
   '() => (contains '())
-  '(1) => (contains '()) 
-  '(1) => (contains '(1)) 
+  '(1) => (contains '())
+  '(1) => (contains '(1))
   '(1 2 3) => (contains '(1))
   '(1 2 3) => (contains '(2))
   '(1 2 3) => (contains '(3))
@@ -240,7 +240,7 @@
   ( (contains '(1 2 1)) '(1 2 2 1)) => falsey ; duplicates matter
 
   "can contain single elements"
-  '(1 2 3) => (contains 3) 
+  '(1 2 3) => (contains 3)
 
   "vectors"
   [3 2 1] => (contains [1])
@@ -263,7 +263,7 @@
   [ {:a 1} {:b 1}      ] => (contains [ {:a 1} ])
   [ {:a 1} "irrelevant"] => (contains   {:a 1})
 
-  ( (contains [ {:a 1} ])  [ {:a 1, :b 1} ]) => falsey  
+  ( (contains [ {:a 1} ])  [ {:a 1, :b 1} ]) => falsey
   ( (contains {:a 1}) [ {:a 2} ]) => falsey
   ( (contains {:a 1}) [ 1 2 3 ]) => falsey
   ( (contains {:a 1}) [ [:a 1] ]) => falsey ; I suppose could arguably be true.
@@ -350,13 +350,13 @@
 
   "lists"
   '() => (contains '() :in-any-order)
-  '(1) => (contains '() :in-any-order) 
-  '(1) => (contains '(1) :in-any-order) 
+  '(1) => (contains '() :in-any-order)
+  '(1) => (contains '(1) :in-any-order)
   '(1 2 3) => (contains '(1) :in-any-order)
   '(1 2 3) => (contains '(2) :in-any-order)
   '(1 2 2 3) => (contains '(2 3 2) :in-any-order)
   ( (contains '(3 2 2) :in-any-order) '(1 2 3) ) => falsey
-  '(1 2 3) => (contains '(3 2) :in-any-order) 
+  '(1 2 3) => (contains '(3 2) :in-any-order)
 
   '(1 2 3) => (contains '(2 3) :in-any-order)
   '(3 2 1) => (contains '(1) :in-any-order)
@@ -376,7 +376,7 @@
   "vectors"
   [3 2 1] => (contains [1] :in-any-order)
   [1 nil 2 3 nil] => (contains [odd? even? odd? nil? nil] :in-any-order)
-  [3 2 1] => (contains [1 2] :in-any-order) 
+  [3 2 1] => (contains [1 2] :in-any-order)
   ( (contains [2 2] :in-any-order) [2]) => falsey ; duplicates matter
 
   "seqs"
@@ -395,7 +395,7 @@
   [ {:a 1} {:b 1}      ] => (contains [ {:b 1} {:a 1} ] :in-any-order)
   [ {:a 1} "irrelevant"] => (contains   "irrelevant" :in-any-order)
 
-  ( (contains [ {:a 1} ] :in-any-order)  [ {:a 1, :b 1} ]) => falsey  
+  ( (contains [ {:a 1} ] :in-any-order)  [ {:a 1, :b 1} ]) => falsey
   ( (contains {:a 1} :in-any-order) [ {:a 2} ]) => falsey
   ( (contains {:a 1} :in-any-order) [ 1 2 3 ]) => falsey
   ( (contains {:a 1} :in-any-order) [ [:a 1] ]) => falsey ; I suppose could arguably be true.

--- a/test/midje/checking/checkers/t_combining.clj
+++ b/test/midje/checking/checkers/t_combining.clj
@@ -11,7 +11,7 @@
                                (fn [actual] (= (str actual) "5" )))]
 
     checker => checker?
-    
+
     (checker 5) => truthy
     (checker 400) => falsey  ; not odd
     (checker 99) => falsey   ; not close to 5
@@ -23,7 +23,7 @@
     3 =not=> checker))
 
 
-;; every-checker 
+;; every-checker
 (facts "about form of the failure value"
   (let [sanitized (fn [actual]
                     (data-laden-falsehood-to-map
@@ -64,7 +64,7 @@
     #"12*" => (every-checker regex? #"12*")))
 (fact "You can even use explicit values"
   5 => (every-checker 5 odd? (roughly 5)))
-  
+
 
 (fact "the empty every-checker passes"
   5 => (every-checker))
@@ -79,7 +79,7 @@
 ;; some-checker
 
 
-(facts "about some-checker" 
+(facts "about some-checker"
   (some-checker truthy falsey)  => checker?
   3 =>     (some-checker truthy falsey)
   3 =not=> (some-checker falsey string?)

--- a/test/midje/checking/checkers/t_simple.clj
+++ b/test/midje/checking/checkers/t_simple.clj
@@ -36,7 +36,7 @@
 (facts "about exactly"
   #'exactly => checker?
   exactly => checker?
-  (exactly odd?) => checker? 
+  (exactly odd?) => checker?
   true => (exactly true)
   ( (exactly 2) 2) => truthy
   ( (exactly 1) 2) => falsey
@@ -66,7 +66,7 @@
     -1 => (roughly -1)
     -1.00001 => (roughly -1)
     -0.99999 => (roughly -1)
-  
+
     -1 => (roughly -1 0.1)
     -0.90001 => (roughly -1 0.1)
     -1.00001 => (roughly -1 0.1))
@@ -87,12 +87,12 @@
 (facts "about throws"
   (throws NullPointerException) => checker?
   (throws NullPointerException "hi") => checker?
-  
+
   (throw-exception) => (throws NullPointerException)
   (throw-exception "hi") => (throws Error "hi")
   (throw-exception "hi") => (throws Error #"h."))
 
-(silent-fact 
+(silent-fact
  (throw-exception "throws Error") => (throws NullPointerException)
  (throw-exception "throws Error") => (throws Error "bye"))
 (note-that (fails 2 times))
@@ -148,10 +148,10 @@
 (fact "Checkers turn unexpected exceptions into `false`"
   (silent-fact (throw-exception "throws Error") => anything)
   (note-that fact-fails, (fact-captured-throwable-with-message #"throws Error"))
-  
+
   (silent-fact (throw-exception "throws Error") => falsey)
   (note-that fact-fails, (fact-captured-throwable-with-message #"throws Error"))
-  
+
   (silent-fact (throw-exception "throws Error") => truthy)
   (note-that fact-fails, (fact-captured-throwable-with-message #"throws Error")))
 

--- a/test/midje/checking/t_core.clj
+++ b/test/midje/checking/t_core.clj
@@ -18,14 +18,14 @@
 (facts "about data-laden falsehoods"
   (as-data-laden-falsehood [5]) => data-laden-falsehood?
   (meta (as-data-laden-falsehood (with-meta [5] {:foo true}))) => (contains {:foo true}))
-  
+
 (facts "user-friendly-falsehood converts extended-falsehood into just false"
   (user-friendly-falsehood false) => false
   (user-friendly-falsehood nil) => nil
   (user-friendly-falsehood (as-data-laden-falsehood {})) => false)
 
-  
-  
+
+
 
 
 (future-fact "should extended-= return strictly true or false?")
@@ -49,7 +49,7 @@
 
 (fact "Big decimal ignore additional 0 in fraction"
   (extended-= 1M 1M) => truthy
-  (extended-= 1M 1.0M) => truthy      
+  (extended-= 1M 1.0M) => truthy
   (extended-= 1M 1.0) => falsey)
 
 (fact "extended equality can be applied to lists"
@@ -61,7 +61,7 @@
   (fact "counts must match"
     (extended-list-= [] [1]) => falsey
     (extended-list-= [1] []) => falsey))
-    
+
 
 (defrecord AB [a b])
 (defrecord AB2 [a b])
@@ -89,7 +89,7 @@
   (extended-= (AB. 1 2) {:a 1, :b 2, :c 3}) => falsey
   (extended-= (assoc (AB. 1 2) :c 3) {:a 1, :b 2, :c 3}) => truthy
   )
-  
+
 (fact "for functions, you can get information about the failure"
   (first (evaluate-checking-function odd? 3)) => true
   (evaluate-checking-function odd? 4) => [false {}]

--- a/test/midje/data/t_compendium.clj
+++ b/test/midje/data/t_compendium.clj
@@ -26,7 +26,7 @@
 
 (def named (a-fact "named" '(fact (+ 1 1) => 2)))
 (def unnamed (a-fact nil '(fact 3 => odd?)))
-  
+
 
 ;;; The direct functions
 
@@ -77,9 +77,9 @@
 
   (named-fact (fresh) 'no-such-namespace "something")
   => (throws Error #"no-such-namespace.*never been loaded"))
-  
 
-    
+
+
 (fact "deleting from the compendium"
   ;; Note: even if the last fact checked is deleted from the compendium,
   ;; it remains the last-fact-checked. (More strictly: I'm leaving the behavior
@@ -113,7 +113,7 @@
     (let [compendium (-> (fresh)
                          (add-to named)
                          (remove-namespace-facts-from common-namespace))]
-      (all-facts compendium) => empty?    
+      (all-facts compendium) => empty?
       (namespace-facts compendium common-namespace) => empty?
       (named-fact compendium common-namespace (fact/name named)) => nil
       (fact-with-guid compendium common-namespace (fact/guid named)) => nil))
@@ -121,7 +121,7 @@
     (let [compendium (-> (fresh)
                          (add-to named)
                          (remove-namespace-facts-from (the-ns common-namespace)))]
-      (all-facts compendium) => empty?    
+      (all-facts compendium) => empty?
       (namespace-facts compendium common-namespace) => empty?
       (named-fact compendium common-namespace (fact/name named)) => nil
       (fact-with-guid compendium common-namespace (fact/guid named)) => nil))
@@ -134,7 +134,7 @@
               (add-to existing)
               (previous-version possible-match)))]
   (tabular "previous version"
-    (fact 
+    (fact
       (let [existing ?existing
             possible-match ?possible]
         (check existing possible-match) => ?expected))
@@ -162,17 +162,17 @@
     ;; (which ought to be impossible)
     (a-fact "name1" '(fact same source))
     (a-fact nil '(fact same source))                      nil
-    
+
     ;; Not fooled by different namespaces and same name
     (a-fact "name1" '(fact same-source))
     (vary-meta (a-fact "name1" '(fact same-source)) assoc :midje/namespace 'clojure.core)
                                                           nil
-            
+
     ;; ... or different namespaces and same source
     (a-fact nil '(fact same-source))
     (vary-meta (a-fact nil '(fact same-source)) assoc :midje/namespace 'clojure.core)
                                                           nil
-            
+
     ))
 
 ;; The functions that work on global state
@@ -180,7 +180,7 @@
 (with-isolated-compendium
   ;; Certain facts do not allow themselves to be recorded.
   (fact :check-only-at-load-time (str "foo") => "foo")
-  (fact :check-only-at-load-time 
+  (fact :check-only-at-load-time
     (all-facts<>) => empty?
     ((last-fact-checked<>)) => "No fact has been checked.")
 
@@ -190,6 +190,6 @@
     (fact :check-only-at-load-time
       (all-facts<>) => empty?
       (fact-checking/check-one (last-fact-checked<>)) => true)))
-  
-  
+
+
 

--- a/test/midje/data/t_nested_facts.clj
+++ b/test/midje/data/t_nested_facts.clj
@@ -31,7 +31,7 @@
       (catch Exception e nil))
     (is (= (descriptions) ["level 1"]))))
 
-(deftest outside-of-the-contexts-there-is-no-fact-description-at-all 
+(deftest outside-of-the-contexts-there-is-no-fact-description-at-all
     (is (= (descriptions) [])))
 
 (deftest nested-descriptions-can-take-an-argument-to-tack-on

--- a/test/midje/data/t_prerequisite_state.clj
+++ b/test/midje/data/t_prerequisite_state.clj
@@ -17,7 +17,7 @@
 
 (declare f g)
 
-(tabular 
+(tabular
   (fact "binding maps contain functions that increment a call count"
     (let [fake (fake (?function-reference 1) => 3)
           result-map (binding-map [fake])]
@@ -45,19 +45,19 @@
 
 
 
-         
+
 
 (defn called-because-mock-checking-requires-it [] nil)
 (defn has-faked-function []
   (called-because-mock-checking-requires-it)
   (implements-a-fake? called-because-mock-checking-requires-it))
-         
+
 (fact "A faked function can be identified from its metadata"
   (has-faked-function) => falsey
   (has-faked-function) => truthy
   (provided
     (called-because-mock-checking-requires-it) => 33))
-  
+
 ;;; Handling of default values for fakes
 
 
@@ -86,7 +86,7 @@
   (fact
     (double-partition [1 2] ..xs..) => [[1] [2] [..x1..] [..x2..]]
     (provided (partition-all 1 ..xs..) => [ [..x1..] [..x2..] ]))
-  
+
 
   ;; However you can't override functions that are used by Midje itself
   ;; These are reported thusly:
@@ -97,7 +97,7 @@
                       reported)]
       (and important-error
            (.getMessage (.throwable (:actual important-error))))))
-  
+
   (defn all-even? [xs] (every? even? xs))
 
 
@@ -171,7 +171,7 @@
   (let [fakes [(fake (f 1) => 3)
                (fake (g 1) => 4)
                (fake (#'f 2) => 5)]
-        counts (fn [] 
+        counts (fn []
                  (map #(deref (:call-count-atom %)) fakes))]
     (handle-mocked-call #'f [1] fakes)    (counts) => [1 0 0]
     (handle-mocked-call #'f [1] fakes)    (counts) => [2 0 0]

--- a/test/midje/data/t_project_state.clj
+++ b/test/midje/data/t_project_state.clj
@@ -13,7 +13,7 @@
   (fact "from symbols or strings"
     (unglob-partial-namespaces ["explicit-namespace1"]) => ['explicit-namespace1]
     (unglob-partial-namespaces ['explicit-namespace2]) => ['explicit-namespace2])
-  
+
   (fact "can 'unglob' wildcards"
     (prerequisites (ecosystem/leiningen-paths) => ["test" "src"]
                    (tude/classify-dir-entries "test/ns/foo") => [{:status :contains-namespace
@@ -44,7 +44,7 @@
 
     (latest-modification-time empty-tracker) => 11
     (latest-modification-time tracker-with-changes) => 3333
-    
+
     (prepare-for-next-scan empty-tracker) => (contains {time-key 11, unload-key [], load-key []})
     (prepare-for-next-scan tracker-with-changes) => (contains {time-key 3333, unload-key [], load-key []})
     (prepare-for-next-scan tracker-with-deleled-ns) => (contains {deps-key {:dependents {..ns1.. #{..ns3..}}}})))
@@ -79,7 +79,7 @@
     (require ..ns1.. :reload) => nil
     (require ..ns2.. :reload) => nil)
 
-  
+
 
   (let [throwable (Error.)]
     (require-namespaces! [..ns1.. ..ns2.. ..ns3..] record-failure cleaner) => anything

--- a/test/midje/emission/plugins/t_default.clj
+++ b/test/midje/emission/plugins/t_default.clj
@@ -22,7 +22,7 @@
         desc-fact (with-meta (fn[]) {:midje/description "desc"})
         unnamed (with-meta (fn[]) {:midje/file "file" :midje/line 3})]
 
-    
+
     (fact "prints names in preference to descriptions"
       (innocuously :starting-to-check-fact name+desc-fact) => #"Checking named"
       (innocuously :starting-to-check-fact desc-fact) => #"Checking desc"

--- a/test/midje/emission/plugins/t_default_end_to_end.clj
+++ b/test/midje/emission/plugins/t_default_end_to_end.clj
@@ -38,15 +38,15 @@
  (config/with-augmented-config {:visible-future true}
    (future-fact 1 => 2))
  (fact @fact-output => #"(?s)WORK TO DO\S* at \(t_default_end_to_end"))
-              
-(capturing-fact-output 
+
+(capturing-fact-output
  (config/with-augmented-config {:visible-future true}
    (future-fact :some-metadata "fact name" 1 => 2))
  (fact @fact-output => #"(?s)WORK TO DO\S* \"fact name\" at \(t_default_end_to_end"))
 
-(capturing-fact-output 
+(capturing-fact-output
  (config/with-augmented-config {:visible-future true}
-   (fact "outer" 
+   (fact "outer"
      (fact "inner" (cons (first 3)) =future=> 2)))
  (fact @fact-output => #"(?s)WORK TO DO\S* \"outer - inner - on `\(cons \(first 3\)\)`\" at \(t_default_end_to_end"))
 

--- a/test/midje/emission/plugins/t_default_failure_lines.clj
+++ b/test/midje/emission/plugins/t_default_failure_lines.clj
@@ -8,7 +8,7 @@
 
 
 ;;; Note that this will scrozzle the failure notice from the facts below
-;;; if they fail. 
+;;; if they fail.
 (against-background [(util/failure-notice anything) => "notice"]
 
   (fact "the simplest kind of failure"
@@ -23,11 +23,11 @@
       (provided
         (util/attractively-stringified-value ..expected..) => 'EEE
         (util/attractively-stringified-value ..actual..) => 'AAA))
-    
-    (fact "or an unexpected match" 
+
+    (fact "or an unexpected match"
       (summarize {:type :actual-result-should-not-have-matched-expected-value :expected-result 2, :actual 2})
       => (just "notice" #"\s+Expected: Anything BUT 2", #"\s+Actual: 2")
-      
+
       ;; in general...
       (summarize {:type :actual-result-should-not-have-matched-expected-value :expected-result
                   ..expected.. :actual ..actual..})
@@ -96,7 +96,7 @@
     )
 
 
-  (fact "prerequisites" 
+  (fact "prerequisites"
     (fact "called with unexpected arguments"
       (fact "a typical case"
         (summarize {:type :prerequisite-was-called-with-unexpected-arguments
@@ -147,5 +147,5 @@
                   #"one"
                   #"two"]
                  :gaps-ok))
-  
+
 )  ;; Against-background

--- a/test/midje/emission/plugins/t_util.clj
+++ b/test/midje/emission/plugins/t_util.clj
@@ -19,11 +19,11 @@
 
 
 (tabular "descriptions harvested from nested facts can be formatted as '-' separated"
-  (fact 
+  (fact
     (format-nested-descriptions descriptions) => result)
-  
+
   descriptions      result
-  ["a" "b" "c"]     "a - b - c" 
+  ["a" "b" "c"]     "a - b - c"
   ["a" nil "c"]     "a - c"
   nil               nil
   []                nil

--- a/test/midje/emission/t_api.clj
+++ b/test/midje/emission/t_api.clj
@@ -22,7 +22,7 @@
 
 
 (defmacro innocuously [& body]
-  `(without-changing-cumulative-totals     
+  `(without-changing-cumulative-totals
     (state/with-emission-map plugin/emission-map
       (state/reset-output-counters!)
       (plugin/reset-recorder!)
@@ -51,7 +51,7 @@
    (config/at-print-level (levels/level-above :print-nothing) (emit/fail ..failure-map..)))
   => (contains {:midje-failures 2})
   (plugin/recorded) => [[:fail ..failure-map..]])
-     
+
 (fact emit/starting-to-check-top-level-fact
   (innocuously
     (config/at-print-level (levels/level-below :print-facts) (emit/starting-to-check-top-level-fact ..ignored-fact-function..))

--- a/test/midje/emission/t_boundaries.clj
+++ b/test/midje/emission/t_boundaries.clj
@@ -22,18 +22,18 @@
     (all-test-failures-to-self-documenting-map {:fail 0 :error 0}) => {:failures 0}
     (provided
       (state/output-counters) => {:midje-failures 0})
-    
+
     (all-test-failures-to-self-documenting-map {:fail 1 :error 0}) => {:failures 1}
     (provided
       (state/output-counters) => {:midje-failures 0})
-    
+
     (all-test-failures-to-self-documenting-map {:fail 0 :error 1}) => {:failures 1}
     (provided
       (state/output-counters) => {:midje-failures 0})
-    
+
     (all-test-failures-to-self-documenting-map {:fail 1 :error 0}) => {:failures 3}
     (provided
       (state/output-counters) => {:midje-failures 2})))
-    
 
-    
+
+

--- a/test/midje/emission/t_colorize.clj
+++ b/test/midje/emission/t_colorize.clj
@@ -11,7 +11,7 @@
 
     (color/init!)
     (?color-fn "string") => ?result)
-        
+
   ?color-fn     ?env-choice   ?config-choice   ?result
 
   ;; On windows, the config-choice defaults to false
@@ -38,7 +38,7 @@
     (prerequisite (getenv "MIDJE_COLORIZE") => ?env-value)
     (color/init!)
     (?color-fn "string") => ?result)
-        
+
   ?color-fn     ?env-value        ?result
   color/fail    "FALSE"           "string"
   color/fail    "TRUE"            "\u001b[31mstring\u001b[0m"

--- a/test/midje/emission/t_deprecation.clj
+++ b/test/midje/emission/t_deprecation.clj
@@ -17,7 +17,7 @@
      (fact "... unless the config asks for everything"
        (config/with-augmented-config {:visible-deprecation :all}
          (with-out-str (deprecate "test message")) => #"test message")))))
-    
+
 (fact "deprecation global message"
   (let [global-message-regex #"(?sm)set configuration variable"]
     (config/with-augmented-config {:visible-deprecation true}
@@ -28,11 +28,11 @@
         (config/with-augmented-config {:visible-deprecation :all}
           (without-previous-deprecations
            (with-out-str (deprecate "test message")) =not=> global-message-regex))))))
-      
+
 (fact "visible deprecation can be turned off"
   (config/with-augmented-config {:visible-deprecation false}
     (without-previous-deprecations
      (with-out-str (deprecate "test message")) => "")))
-    
-  
-  
+
+
+

--- a/test/midje/parsing/0_to_fact_form/t_tabular.clj
+++ b/test/midje/parsing/0_to_fact_form/t_tabular.clj
@@ -27,28 +27,28 @@
 (let [c 1]
   (tabular "considers local bindings to be table values, not headings"
     (fact (+ a b) => result )
-  
+
        a  b      result
-       c  2      3       ;; need second row, else (in the failure case) this  
-       4  5      9))     ;; mis-parsing tabular will think there are 0 rows     
+       c  2      3       ;; need second row, else (in the failure case) this
+       4  5      9))     ;; mis-parsing tabular will think there are 0 rows
 
 (defn f? [x] true)
 
 (tabular "won't consider bound resolvable fns as table heading var"
-  (fact (+ a b) => result)    
+  (fact (+ a b) => result)
      result  a   b
-     f?      1   2    ;; needs second row, like above 
+     f?      1   2    ;; needs second row, like above
      17      8   9)
-                      
-(tabular "won't think of metaconstants as unbound symbols, and thus 
+
+(tabular "won't think of metaconstants as unbound symbols, and thus
           won't try to make them table heading variables"
   (fact 'candidate arrow metaconstant-symbol?)
      candidate   arrow
-     ---foo---     => 
+     ---foo---     =>
      -foo-         => )
 
 (tabular "The tabular form can have a doc string"
- (fact 
+ (fact
    (+ ?a ?b) => ?result)
  ?a    ?b      ?result
  1     2       3)
@@ -56,7 +56,7 @@
 ;; Table Validation
 
 (silent-tabular
- (fact 
+ (fact
    (tabular-forms '?forms) => '?expected
    ?forms                       ?expect
    [ fact table ]               [fact table]))
@@ -72,7 +72,7 @@
  (fact ?a => ?b)
    ?a   ?b)
 (note-that (fact-failed-with-note #"It looks like the table has headings, but no values"))
- 
+
 (silent-tabular
  (fact
    (+ a b) => result)
@@ -94,12 +94,12 @@
  (+ 1 2) 1      2
  3       2      2)
 
-                                     
+
 (tabular
  (fact "only two numbers have the same sum and square"
    (* ?n ?n) ?arrow (+ ?n ?n))
  ?n        ?arrow
- 0         =>      
+ 0         =>
  2         =>
  ;; Failure cases
  1         =not=>
@@ -120,10 +120,10 @@
 
   ?cell-status   ?neighbor-count   ?expected
   :alive         1                 FALSEY        ; underpopulation
-  :alive         2                 truthy       
+  :alive         2                 truthy
   :alive         3                 truthy
   :alive         4                 FALSEY        ; overpopulation
-  
+
   ;; A newborn cell has three parents
   :dead          2                 FALSEY
   :dead          3                 truthy
@@ -147,7 +147,7 @@
    (fact @fact-output => #"WORK TO DO")))
 
 ;; Util: table-binding-maps
- 
+
 (fact "gets the bindings off fact table"
   (table-binding-maps ['?a  '?b '?result] [1 2 3])
   => [ (ordered-map '?a 1, '?b 2, '?result 3) ])
@@ -157,9 +157,9 @@
 
 (tabular "table of results"
   (silent-fact (+ a b) => result)
-    
+
       a    b   result
-      2    4   999     )  ;; PURPOSELY FAIL 
+      2    4   999     )  ;; PURPOSELY FAIL
 (note-that fact-fails, (fact-described-as  "table of results" nil))
 
 
@@ -167,7 +167,7 @@
 (tabular
   (silent-fact "add stuff"  ;; Note that this gets promoted to be with `tabular`
       (+ a b) => result)
-    
+
       a    b   result
       2    4   999     )  ;; PURPOSELY FAIL
 (note-that fact-fails, (fact-described-as  "add stuff" nil))
@@ -179,18 +179,18 @@
 (fact :check-only-at-load-time
   (fact-data/source (compendium/last-fact-checked<>)) => '(tabular (fact ?a => 1) ?a 1 1)
   (fact-data/guid (compendium/last-fact-checked<>)) => (random/form-hash '((fact ?a => 1) ?a 1 1)))
-  
+
 (tabular "name" :integration (fact ?a => 1) ?a 1 1)
 (fact :check-only-at-load-time
   (fact-data/source (compendium/last-fact-checked<>)) => '(tabular "name" :integration (fact ?a => 1) ?a 1 1)
   (fact-data/guid (compendium/last-fact-checked<>)) => (random/form-hash '((fact ?a => 1) ?a 1 1))
   (:integration (meta (compendium/last-fact-checked<>))) => true)
-  
+
 (tabular (fact "name" :integration ?a => 1) ?a 1 1)
 (fact :check-only-at-load-time
   (fact-data/source (compendium/last-fact-checked<>)) => '(tabular (fact "name" :integration ?a => 1) ?a 1 1)
   (fact-data/guid (compendium/last-fact-checked<>)) => (random/form-hash '((fact ?a => 1) ?a 1 1))
   (:integration (meta (compendium/last-fact-checked<>))) => true)
-  
+
 
 

--- a/test/midje/parsing/1_to_explicit_form/t_expects.clj
+++ b/test/midje/parsing/1_to_explicit_form/t_expects.clj
@@ -36,7 +36,7 @@
         resulting-loc (wrap-with-expect__then__at-rightmost-expect-leaf original-loc)]
     original-loc => (node `(f 1))
     original-loc => recognize/start-of-checking-arrow-sequence?
-    
+
     (zip/root resulting-loc) => edited
     (zip/next resulting-loc) => (node "next"))
 
@@ -49,25 +49,25 @@
         resulting-loc (wrap-with-expect__then__at-rightmost-expect-leaf original-loc)]
     original-loc => (node `(f 1))
     original-loc => recognize/start-of-checking-arrow-sequence?
-    
+
     (zip/root resulting-loc) => edited
     (zip/next resulting-loc) => (node "next"))
 
 
   (let [original `( (f 1) => (+ 2 3) :key "value"  "next")
-        edited   `( (expect (f 1) => (+ 2 3) :key "value") "next")   
+        edited   `( (expect (f 1) => (+ 2 3) :key "value") "next")
         z             (zip/seq-zip original)
         original-loc  (-> z zip/down)
         resulting-loc (wrap-with-expect__then__at-rightmost-expect-leaf original-loc)]
     original-loc => (node `(f 1))
     original-loc => recognize/start-of-checking-arrow-sequence?
-    
+
    (zip/root resulting-loc) => edited
    (zip/next resulting-loc) => (node "next"))
 
   "annotations on the original form are preserved"
   (let [original `( (f 1) => (+ 2 3) :key "value")
-        edited   `( (expect (f 1) => (+ 2 3) :key "value"))   
+        edited   `( (expect (f 1) => (+ 2 3) :key "value"))
         z             (zip/seq-zip original)
         original-loc  (-> z zip/down)
         resulting-loc (wrap-with-expect__then__at-rightmost-expect-leaf original-loc)]

--- a/test/midje/parsing/1_to_explicit_form/t_metaconstants.clj
+++ b/test/midje/parsing/1_to_explicit_form/t_metaconstants.clj
@@ -37,7 +37,7 @@
     (provided
       ...source... =contains=> '{:a a, :b b}
       ...source... =contains=> {:c c})))
-  
+
 
 (unfinished m)
 (defn caller [head tail]
@@ -48,7 +48,7 @@
   (provided (m 'sym ...tail...) => '(sym ...tail...)))
 
 (defn claim-symbols [symbols]
-  (fact 
+  (fact
     (doseq [metaconstant-symbol symbols]
       (find (ns-interns *ns*) metaconstant-symbol) => truthy
       (var-get ((ns-interns *ns*) metaconstant-symbol)) => metaconstant-symbol)))
@@ -57,7 +57,7 @@
 (declare f)
 (background (f ...one...) => 1 )
 (against-background [ (f ...two...) => 2 ]
-  (fact 
+  (fact
     (+ (f ...one...) (f ...two...) (f ...three...))  => 6
     (against-background (f ...three...) => 3)))
 (claim-symbols '(...one... ...two... ...three...))

--- a/test/midje/parsing/1_to_explicit_form/t_prerequisites.clj
+++ b/test/midje/parsing/1_to_explicit_form/t_prerequisites.clj
@@ -19,12 +19,12 @@
         z (zip/seq-zip original)
         loc (zip/down z)]
     (expand-prerequisites-into-fake-calls loc) => translated))
-  
+
 
 (fact "created fakes have the line number of the arrow form"
   (let [args `( ~(at-line 789 '(f 1)) => 3)]
     (:line (meta (prerequisite-to-fake args))) => 789))
-     
+
 (fact "prerequisite containers are deleted so their contents can be inserted elsewhere"
   (let [original '( (expect (f x) => (+ 1 2)) (provided ...) "next")
         edited   '( (expect (f x) => (+ 1 2))                "next")
@@ -32,7 +32,7 @@
         original-loc (-> z zip/down zip/right zip/down)
         resulting-loc
          (delete_prerequisite_form__then__at-previous-full-expect-form original-loc)]
-        
+
     original-loc => recognize/provided?
     resulting-loc => recognize/expect?
     (zip/root resulting-loc) => edited))

--- a/test/midje/parsing/2_to_lexical_maps/t_expects.clj
+++ b/test/midje/parsing/2_to_lexical_maps/t_expects.clj
@@ -17,9 +17,9 @@
 
 ;; I don't know why `expect` (and it alone) has to be fully qualified for these
 ;; tests to pass, but it does. Because these tests are mostly holdovers from when
-;; users could use `expect` directly, I'm not overly concerned. 
+;; users could use `expect` directly, I'm not overly concerned.
 
- 
+
 (unfinished faked-function mocked-function other-function)
 
 ;;;
@@ -168,7 +168,7 @@
 
 (facts "about checkers"
   (fact "expected results can be functions"
-    (midje.parsing.2-to-lexical-maps.expects/expect (+ 1 1) => even?))  
+    (midje.parsing.2-to-lexical-maps.expects/expect (+ 1 1) => even?))
 
   (fact "exact function matches can be checked with exactly"
     (let [myfun (constantly 33)
@@ -246,10 +246,10 @@
   :check-only-at-load-time
   (fact "calls macro to expand and compares to (unquoted) list"
     (some-macro 8) =expands-to=> (clojure.core/+ 100 200 8))
-  
+
   (fact "fails if expansion does not match expected list"
     (silent-fact (some-macro 1) =expands-to=> (clojure.core/- 100 200 1))
     (note-that fact-failed,
                (fact-actual `(clojure.core/+ 100 200 1))
                (fact-expected (quote (clojure.core/- 100 200 1))))))
- 
+

--- a/test/midje/parsing/2_to_lexical_maps/t_folded_fakes.clj
+++ b/test/midje/parsing/2_to_lexical_maps/t_folded_fakes.clj
@@ -22,13 +22,13 @@
 
 (defmacro some-macro [& rest] )
 
-(tabular "things that are not fake-sexps don't need to be unfolded" 
+(tabular "things that are not fake-sexps don't need to be unfolded"
 (fact ?thing ?arrow folded-fake?)
 
   ;; things not a proper fake macro
   ?thing                                        ?arrow
-  '1                                            =not=> 
-  '()                                           =not=> 
+  '1                                            =not=>
+  '()                                           =not=>
   `(fake (f (h 1)))                             =not=> ; not in right namespace
   '(midje.parsing.2-to-lexical-maps/non-fake (f (h 1)))             =not=>
 
@@ -38,26 +38,26 @@
 (tabular
   (fact "unfolding depends on the inner structure of a funcall"
     (list `fake '?call =test=> 3) ?arrow folded-fake?)
-   
+
   ?call                  ?arrow
   ;; Things that might be misinterpreted as nested funcalls
-  (f)                  =not=> 
-  (f 1)                =not=> 
-  (f 1 '(foo))         =not=> 
-  (f 1 [foo])          =not=> 
-  (f 1 {foo 1})        =not=> 
-  
+  (f)                  =not=>
+  (f 1)                =not=>
+  (f 1 '(foo))         =not=>
+  (f 1 [foo])          =not=>
+  (f 1 {foo 1})        =not=>
+
   ;; These are real nested function calls
-  (f (h 1))              => 
-  (f 1 (h 1))            => 
-  
+  (f (h 1))              =>
+  (f 1 (h 1))            =>
+
   ;; but don't decide to unfold a checker used as argument matcher"
   (f 1 (exactly even?))  =not=>
 
   ;; don't unfold a constructor.
   (f (java.util.Date. 1 1 1))           =not=>
   (f (new java.util.Date 1 2 2))        =not=>
-  
+
   "Macros are surprisingly hard to get right"
 ;  '(f 1 (some-macro 33))  =not=> folded-fake?
   )

--- a/test/midje/parsing/3_from_lexical_maps/t_from_fake_maps.clj
+++ b/test/midje/parsing/3_from_lexical_maps/t_from_fake_maps.clj
@@ -39,7 +39,7 @@ odd?                   3               falsey)
   ((mkfn:arglist-matcher-fixed-arity 1 2) [1    ]) => falsey
   ((mkfn:arglist-matcher-fixed-arity 1 2) [1 2  ]) => truthy
   ((mkfn:arglist-matcher-fixed-arity 1 2) [1 2 3]) => falsey)
-    
+
 (fact "an arglist can allow rest args"
   ((mkfn:arglist-matcher-allowing-optional-args 1 2 & anything) [1    ]) => falsey
   ((mkfn:arglist-matcher-allowing-optional-args 1 2 & anything) [1 2  ]) => truthy
@@ -53,12 +53,12 @@ odd?                   3               falsey)
     ((mkfn:arglist-matcher-allowing-optional-args 1 2 & (as-checker empty?)) [1 2]) => truthy
     ((mkfn:arglist-matcher-allowing-optional-args 1 2 &             empty? ) [1 2]) => falsey
     ((mkfn:arglist-matcher-allowing-optional-args 1 2 & (as-checker empty?)) [1 2 3]) => falsey))
-  
+
 (facts "about result suppliers used"
   "returns identity for =>"
   (let [arrow "=>"]
     ((mkfn:result-supplier arrow [1 2 3])) => [1 2 3])
-             
+
   "returns stream for =streams=>"
   (let [supplier (mkfn:result-supplier "=streams=>" [1 2 3])]
     (supplier) => 1

--- a/test/midje/parsing/other/t_arglists.clj
+++ b/test/midje/parsing/other/t_arglists.clj
@@ -16,11 +16,11 @@
 
   (separate-print-levels [:print-nothing :all] ..irrelevant..)
   => [[:print-nothing] :print-nothing [:all]]
-  
+
   (let [number-form (print-levels/names-to-levels :print-facts)]
     (separate-print-levels ['a number-form 'b] ..irrelevant..)
     => [[number-form] number-form '[a b]])
-  
+
   ;; checks for valid levels
   (separate-print-levels [500 'something] ..irrelevant..)
   => (throws Error #"500.*not.*valid")
@@ -56,15 +56,15 @@
 
 
 
-  
+
 (fact "arglist parser with :options"
   (let [flag-descriptions [[:dirs :dir] [:interval]]
         parser (apply make-option-arglist-parser flag-descriptions)]
-     
+
     (fact "can find true args"
     (parser []) => (contains {:true-args []})
     (parser [:dirs]) => (contains {:true-args []}))
-      
+
     (fact "can find flags that are present"
       (parser ['arg :dirs 1 2]) => (contains '{:dirs? true :dirs-args [1 2]}))
 

--- a/test/midje/parsing/util/t_core.clj
+++ b/test/midje/parsing/util/t_core.clj
@@ -23,4 +23,4 @@
   (dequote 1) => 1
   (dequote '(some form)) => '(some form))
 
-  
+

--- a/test/midje/t_repl.clj
+++ b/test/midje/t_repl.clj
@@ -59,7 +59,7 @@
       (load-facts (the-ns 'midje.t-repl-helper) :print-no-summary)
       (count (fetch-facts)) => 2
       (filter #(= (fact-name %) "FAKE") (fetch-facts :all)) => empty?)
-  
+
     (fact "metadata filters are obeyed"
       (load-facts 'midje.t-repl-helper :non-featherian :print-no-summary)
       (map fact-name (fetch-facts :all)) => ["a non-featherian test"]
@@ -104,13 +104,13 @@
       => (contains '{:given-level-args [:print-no-summary]
                     :given-filter-args [:non-featherian]
                     :given-namespace-args [midje.t-repl-helper]}))
-    
+
   )
   )
 
 ;;;; ==== PART 2: Working with loaded facts
 
- 
+
                                 ;;; Fetching facts
  (compendium/fresh!)
 
@@ -145,7 +145,7 @@
    (let [expected ["z - first - integration" "f - second - midje.parsing.1-to-explicit-form.facts"]]
      (names (fetch-facts :all "n")) => expected
      (names (fetch-facts)) => expected)
-   
+
    (names (fetch-facts 'midje.parsing.1-to-explicit-form.facts #"q")) => []
    (names (fetch-facts :all :integration)) => ["z - first - integration"]
    (names (fetch-facts *ns* :integration)) => []
@@ -154,7 +154,7 @@
    => ["f - second - midje.parsing.1-to-explicit-form.facts" "p - third - midje.repl"]
    )
 
-   
+
 
 
                                 ;;; Forgetting facts
@@ -225,7 +225,7 @@
       (load-facts 'midje.t-repl-helper :print-nothing)
       (forget-facts)
       (map fact-name (compendium/all-facts<>)) => ["not forgotten"])
-    
+
     (fact "it can get its default from check-facts"
       (forget-facts :all)
       (load-facts 'midje.t-repl-helper :print-nothing)
@@ -233,7 +233,7 @@
       (forget-facts)
       (map fact-name (compendium/namespace-facts<> 'midje.t-repl-helper))
       =not=> ["a non-featherian test"])
-    
+
     (fact "forget-facts does not affect check-facts"
       (forget-facts :all)
       (load-facts 'midje.t-repl-helper :non-featherian :print-nothing)
@@ -241,7 +241,7 @@
       (forget-facts 'midje.parsing.1-to-explicit-form.facts)
       (map fact-name (fetch-facts)) => ["a non-featherian test"]))
   )
-  
+
 
 
 
@@ -263,7 +263,7 @@
  (let [string-result ; will only be visible for facts defined at the repl.
        (config/with-augmented-config {:fact-filter (with-meta (constantly false)
                                                      {:created-from ["desiderata"]})}
-         
+
          (check-one-fact the-fact))]
    (fact :check-only-at-load-time
      string-result => #"ignored because of the current configuration"
@@ -273,7 +273,7 @@
 
         ;;; Checking multiple facts
 
-;; Create (silently, without affecting totals) a fact to be rechecked later. 
+;; Create (silently, without affecting totals) a fact to be rechecked later.
 (silent-fact "error fact" 1 => 2)
 
  (without-changing-cumulative-totals
@@ -328,7 +328,7 @@
   (fact "confirm the ordering of the two facts"
     :check-only-at-load-time
     (map fact-name (fetch-facts 'midje.t-repl)) => ["1" "2"])
-  
+
   (fact "Even though the first fact failed, both facts were checked"
     :check-only-at-load-time
     (check-facts 'midje.t-repl :print-nothing)
@@ -343,7 +343,7 @@
 
  (without-changing-cumulative-totals
   (config/with-augmented-config {:print-level :print-no-summary}
-  
+
     (fact "Rechecking the fact resets the totals"
       :check-only-at-load-time
       (recheck-fact)
@@ -351,7 +351,7 @@
       (recheck-fact)
       (:midje-passes (state/output-counters)) => 1
       (:midje-failures (state/output-counters)) => 0)
-    
+
     (fact "It also prints a summary"
       :check-only-at-load-time
       (config/with-augmented-config {:print-level :print-normally}
@@ -386,28 +386,28 @@
      (fact "inner"
        (swap! inner-count inc)
        2 => 2))
-   
+
    (fact "only outer fact is available"
      :check-only-at-load-time
      (count (fetch-facts :all)) => 1
      (fact-name (first (fetch-facts :all))) => "outer")
-   
+
    (fact
      :check-only-at-load-time
      (without-changing-cumulative-totals (check-facts :all))
      @outer-count => 2
      @inner-count => 2)
-   
-   
+
+
    ;; Facts with the same name redefine old versions.
    (forget-facts :all)
-   
+
    (def run-count (atom 0))
    (fact "name"
      (swap! run-count inc))
    (fact "name" :redefinition
      @run-count => 1)
-   
+
    (fact "Only the second fact now exists"
      :check-only-at-load-time
      (let [known-facts (fetch-facts :all)]
@@ -415,42 +415,42 @@
        (:redefinition (meta (first known-facts))) => true
        (without-changing-cumulative-totals (check-facts))
        @run-count => 1))
-   
+
    ;; Redefinition of an unnamed fact to an identical body does
    ;; not produce copies.
    (forget-facts :all)
    (fact :note-that-the-metadata-does-not-matter (+ 1 1) => 2)
    (fact :some-other-metadata                    (+ 1 1) => 2)
-   
+
    (fact "the old fact has been replaced"
      :check-only-at-load-time
      (count (fetch-facts :all)) => 1
      (map (comp :some-other-metadata meta) (fetch-facts :all)) => [true])
-   
-   
+
+
    ;; You can add a name to a fact.
    (forget-facts :all)
    (fact                         (+ 1 1) => 2)
    (fact "today we choose faces" (+ 1 1) => 2)
-   
+
    (fact "there is now only a named fact"
      :check-only-at-load-time
      (count (fetch-facts :all)) => 1
      (map fact-name (fetch-facts :all)) => ["today we choose faces"])
-   
-   
+
+
    ;; An unnamed fact does not replace a named one with an identical body.
    ;; It becomes a new fact.
    (forget-facts :all)
    (fact "named" (+ 1 1) => 2)
    (fact         (+ 1 1) => 2)
-   
+
    (fact "There are two facts"
      :check-only-at-load-time
      (count (fetch-facts :all)) => 2
      (map fact-name (fetch-facts :all)) => ["named" nil])
 
-   
+
         ;;; For recheck-fact
 
    (def outer-run-count (atom 0))
@@ -461,7 +461,7 @@
       (fact inner
         (swap! inner-run-count inc)
         (fact (- 1 1) => 0)))
-    
+
     (fact "The last fact check is the outermost nested check"
       :check-only-at-load-time
       (without-changing-cumulative-totals (rcf))
@@ -470,7 +470,7 @@
       @inner-run-count => 2)
 
     ;; Multiple nested facts
-    
+
     (def run-count (atom 0))
     (fact "outermost"
       (fact "inner 1"
@@ -492,13 +492,13 @@
       ?a ?b ?c
       1  2  3
       2  2  4)
-    
+
     (fact :check-only-at-load-time
       (without-changing-cumulative-totals (recheck-fact))
       @run-count => 4)
 
     ;; Facts mark themselves as last-fact-checked each time they're
-    ;; rechecked.  
+    ;; rechecked.
     (fact (+ 1 1) => 2)
     (def one-plus-one (last-fact-checked))
     (fact (+ 2 2) => 4)
@@ -578,18 +578,18 @@
   (fact "skips adding nonexistent files or dirs"
     (captured-output (autotest :files "blah/src" "blah/test")) => anything
     (captured-output (autotest :files "blah/src.clj" "blah/test.clj")) => anything
-    
+
     (captured-output (autotest :dirs "blah/src" "blah/test")) => anything
     (captured-output (autotest :dirs "blah/src.clj" "blah/test.clj")) => anything
 
     (provided
       (set-autotest-option! :files anything) => irrelevant :times 0))
 )
-  
 
 
 
-               
+
+
 ;;;; ==== PART 6: Utilities
 
 (fact "decomposing arglists"
@@ -665,7 +665,7 @@
           (after [command-type first-args second-args]
             (set-previous-args first-args command-type)
             (deduce-user-intention second-args command-type))]
-            
+
     (fact "as before, all left out means all are replaced"
       (after :memory-command '[ns :filter :print-facts] [])
       => (contains {:given-namespace-args '[ns]
@@ -716,7 +716,7 @@
     (deduce-user-intention [] :memory-command)
     => (contains {:given-level-args []})
 
-    
+
     (and-update-defaults!
       (deduce-user-intention '[midje.t-repl :metadata] :disk-command)
       :disk-command)
@@ -741,9 +741,9 @@
          all-pass => true
          all-fail => false
          no-results => nil)))))
-     
 
-              
+
+
 
 
 )      ; confirming-cumulative-totals-not-stepped-on

--- a/test/midje/t_sweet.clj
+++ b/test/midje/t_sweet.clj
@@ -20,12 +20,12 @@
   (map str (remove (comp :doc meta) (vals (ns-publics 'midje.util)))) => []
   (map str (remove (comp :doc meta) (vals (ns-publics 'midje.repl)))) =future=> [])
 
-              
+
 
 
 
 (defn number [] )
-(defn two-numbers [] 
+(defn two-numbers []
   (+ (number) (number)))
 
 
@@ -34,7 +34,7 @@
  (provided
    (number) =throws=> [1]))
 (note-that fact-fails, (fact-captured-throwable-with-message #"Right side of =throws=> should extend Throwable"))
-  
+
 (facts "this is a doc string"
   (+ 10 10) => 20
   "this is another one"
@@ -44,23 +44,23 @@
 (defn f [n] (g n))
 (defn call2 [n m]
   (+ (g n) (g m)))
-  
+
 ;; Some examples of prerequisites
 (fact (f 1) => 33
   (provided (g 1) => 33))
 
-(facts 
+(facts
   (f 1) => 313
   (provided
     (g 1) => 313)
-    
+
   (f 22) => 500
-  (provided 
+  (provided
     (g 22) => 500))
 
-(facts 
+(facts
   (call2 1 2) => 30
-  (provided 
+  (provided
     (g 1) => 10
     (g 2) => 20))
 
@@ -134,7 +134,7 @@
  (provided
    (g (h 1)) => 2
    (i (h 1)) => 1))
-  
+
 (defn nesty [n] (g (h (i (j n)))))
 (fact
  (nesty 1) => 3
@@ -162,7 +162,7 @@
     (let [result (g 1)] result => 5)))    ;; This used to fail
 
 (background (scope-to-fact) => 5)
-(facts 
+(facts
   (g 1) => 5
   (let [result (g 1)] result => 5)    ;; This used to fail
 )
@@ -185,19 +185,19 @@
  (provided
    (called 1) => 1 :times 2))
 (note-that fact-fails, (the-prerequisite-was-incorrectly-called 1 :time))
-  
+
 (silent-fact ":times can be a range"
  (called 1) => 1
  (provided
    (called 1) => 1 :times (range 2 8)))
 (note-that fact-fails, (the-prerequisite-was-incorrectly-called 1 :time))
- 
+
 (silent-fact "times can be a function"
  (do (called 1) (called 1) (called 1)) => 1
  (provided
    (called 1) => 1 :times even?))
 (note-that fact-fails, (the-prerequisite-was-incorrectly-called 3 :times))
-  
+
 (fact "by default, can be called zero or more times"
   (do (called 1) (called 1)) => 1
   (provided
@@ -218,13 +218,13 @@
     (fact "fact returns true on success"
       (+ 1 1) => 2
       "some random return value"))
-  
+
   (def should-be-false-because-of-fact-failure
     (fact "fact returns false on failure"
       (+ 1 1) => 3
       (+ 1 1) => 2
       "some random return value"))
-  
+
   (def should-be-true-despite-previous-failue
     (fact "a fact's return value is not affected by previous failures"
       (+ 1 1) => 2
@@ -260,16 +260,16 @@
   (alter-var-root #'inners conj (silent-fact 2 => 1 "ignored value")))
 (fact inners => [true false])
 
-                         
 
-                         ;;;; 
-                         
+
+                         ;;;;
+
 (defn a [])
 (defn b [] (a))
 
 (fact "prerequisites can throw throwables"
   (b) => (throws Exception)
-  (provided 
+  (provided
     (a) =throws=> (Exception.)))
 
 
@@ -314,7 +314,7 @@
 ;;; point of allowing vars is to refer to private vars in another
 ;;; namespace. To make sure there's no mistakes, these local versions
 ;;; are so tagged.
-;;; 
+;;;
 (defn var-inc-local [x] (inc x))
 (defn var-inc-user-local [x] (* x (var-inc-local x)))
 (defn var-twice-local []
@@ -345,7 +345,7 @@
 
 (defn here-and-there []
   (var-inc-local (#'midje.data.t-prerequisite-state/var-inc 2)))
-  
+
 (fact "vars also work with unfolded prerequisites"
   (here-and-there) => 201
   (provided
@@ -353,7 +353,7 @@
 
 (defn there-and-here []
   (#'midje.data.t-prerequisite-state/var-inc (var-inc-local 2)))
-  
+
 (fact "vars also work with unfolded prerequisites"
   (there-and-here) => 201
   (provided
@@ -362,7 +362,7 @@
 (defn over-there-over-there-spread-the-word-to-beware []
   (#'midje.data.t-prerequisite-state/var-inc
    (#'midje.data.t-prerequisite-state/var-inc 2)))
-  
+
 (fact "vars also work with unfolded prerequisites"
   (over-there-over-there-spread-the-word-to-beware) => 201
   (provided
@@ -372,7 +372,7 @@
  (fact "exceptions do not blow up"
    (odd? "foo") => (throws Exception)
    "foo" =not=> odd?)
-   
+
 ;;; fact groups
 
 (fact-group :integration {:timing 3}
@@ -380,7 +380,7 @@
   (fact (inc 33) => 34)
   (let [stashed (compendium/last-fact-checked<>)]
     (fact (meta stashed) => (contains {:integration true :timing 3}))))
-            
+
 
                                         ;;; fact groups
 

--- a/test/midje/test_util.clj
+++ b/test/midje/test_util.clj
@@ -58,7 +58,7 @@
   (silent-body expanded-symbols/data-fake &form))
 (defmacro silent-check-facts [& _]
   (silent-body 'midje.repl/check-facts &form))
-  
+
 
 ;;; Checkers, mainly for failures
 
@@ -126,17 +126,17 @@
   `(fn [actual-failure#]
      (if-let [match# (intermediate-result-left-match '~left actual-failure#)]
        (= (second match#) ~value))))
-      
+
 (defmacro fact-omitted-intermediate-result [left]
   `(fn [actual-failure#]
      (not (intermediate-result-left-match '~left actual-failure#))))
-  
+
 
 ;; Prerequisites
 
 (def only-incorrect-call-counts (partial filter #(= (:type %) :some-prerequisites-were-called-the-wrong-number-of-times)))
 (def only-incorrect-call-count-reasons (comp all-reasons only-incorrect-call-counts))
-  
+
 
 (defn ^{:all-failures true} some-prerequisite-was-called-with-unexpected-arguments [failure-maps]
   (some #{:prerequisite-was-called-with-unexpected-arguments} (map :type failure-maps)))
@@ -151,7 +151,7 @@
 (defn ^{:all-failures true} prerequisite-was-never-called [expected-call]
   (prerequisite-was-called-the-wrong-number-of-times expected-call 0))
 
-                                 
+
 ;; The following two are to be used when there's only one prerequisite
 
 (defn ^{:all-failures true} the-prerequisite-was-incorrectly-called [n & _times_]
@@ -163,7 +163,7 @@
 
 (defn ^{:all-failures true} failures-were-at-lines [& lines]
   (fn [failure-maps]
-    (= lines 
+    (= lines
        (map line-number-from-failure-reason (all-reasons failure-maps)))))
 
 ;; Misc
@@ -199,7 +199,7 @@
                     (cond (or (= claim 'fact-fails)
                               (= claim 'fact-failed))
                           (tack-on '(@silent-fact:failure-count => pos?))
-                                      
+
                           (or (= claim 'fact-passes)
                               (= claim 'fact-passed))
                           (tack-on '(@silent-fact:failure-count => zero?))
@@ -282,13 +282,13 @@
 
 
 
-(defn at-line [line-no form] 
+(defn at-line [line-no form]
    (with-meta form {:line line-no}))
 
 (defmacro defn-call-countable
   "Note: For testing Midje code that couldn't use provided.
-  
-  Creates a function that records how many times it is called, and records 
+
+  Creates a function that records how many times it is called, and records
   that count in an atom with the same name as the function with \"-count\" appended"
   [name args & body]
   (let [atom-name (symbol (str name "-count"))]

--- a/test/midje/util/t_ecosystem.clj
+++ b/test/midje/util/t_ecosystem.clj
@@ -11,12 +11,12 @@
                                       :source-paths ["src1"]
                                       :test-paths ["test1"])))]
       (leiningen-paths) => ["test1" "src1"]))
-  
+
   (fact "and provides a default if it does not"
     (leiningen-paths) => ["test"]
     (provided
       (load-file "project.clj") =throws=> (new java.io.FileNotFoundException)))
-  
+
   (fact "except that lein-midje can explicitly set the value"
     (set-leiningen-paths! {:test-paths ["t"] :source-paths ["s"]})
     (leiningen-paths) => ["t" "s"])

--- a/test/midje/util/t_laziness.clj
+++ b/test/midje/util/t_laziness.clj
@@ -66,7 +66,7 @@
 (fact "eagerly preserves metadata"
   (meta (eagerly (with-meta (map identity [1 2 3]) {:hi :mom})))
   => {:hi :mom})
-    
+
 (fact "eagerly preserves identical? for non-collections."
   (let [eagered (first (eagerly (map identity [odd?])))]
     eagered => #(identical? % odd?)

--- a/test/midje/util/t_pile.clj
+++ b/test/midje/util/t_pile.clj
@@ -3,10 +3,10 @@
             [midje.test-util :refer :all]
             [midje.util.pile :as subject]))
 
-(fact "apply each function to each corresponding arg" 
+(fact "apply each function to each corresponding arg"
   (subject/apply-pairwise [inc dec] [1 1] [2 2]) => [[2 0] [3 1]])
 
-(fact 
+(fact
   (subject/map-first str [1 2 3]) => ["1" 2 3])
 
 (fact "sort a map"

--- a/test/midje/util/t_thread_safe_var_nesting.clj
+++ b/test/midje/util/t_thread_safe_var_nesting.clj
@@ -45,13 +45,13 @@
   (with-pushed-namespace-values :stacky '(1 2)
     (with-pushed-namespace-values :stacky '(3 4)
       (namespace-values-inside-out :stacky) => '(4 3 2 1)))
-  
+
   "... are not scrozzled by exceptions"
-  (try 
+  (try
     (with-pushed-namespace-values :stacky '(1 2)
       (namespace-values-inside-out :stacky) => '(2 1)
       (throw (Throwable. root)))
     (catch Throwable ex
       (namespace-values-inside-out :stacky) => '())))
-      
-  
+
+

--- a/test/midje/util/t_unify.clj
+++ b/test/midje/util/t_unify.clj
@@ -12,5 +12,5 @@
   (substitute '(without-binding (nil-binding (other-binding)))
          '{nil-binding nil, other-binding 1})
   => '(without-binding (nil (1))))
-  
+
 

--- a/test/user/fus_checkers.clj
+++ b/test/user/fus_checkers.clj
@@ -22,7 +22,7 @@
   [1] => (has-prefix 1)
   [1] => (has-suffix 1)
   [1] => (has every? odd?))
-    
+
 
 
 (future-fact "Failures from chatty-checkers-within-functions propagate chatty information"
@@ -31,11 +31,11 @@
        (let [set-of-sets #(set (map set %))]
          (fn [actual]
            ( (just (set-of-sets expected)) (set-of-sets actual)))))
-     
-     
+
+
      (silent-fact
        [ [1] [2 3] ] => (as-sets [ [1] ]))
-     
+
      @silent-fact:last-raw-failure => (contains {:type :actual-result-did-not-match-checker
                                                  :actual [ [1] [2 3]]
                                                  :expected-result-form '(as-sets [[1]])
@@ -46,17 +46,17 @@
 
 (tabular
   (fact ?actual ?arrow ?expected)
-  
+
   ?expected                      ?actual ?arrow
-  odd?                           3       =>             
+  odd?                           3       =>
   odd?                           odd?    =not=>
-                                                     
+
   (exactly odd?)                 3       =not=>
   (exactly odd?)                 odd?    =>
-  
-  (as-checker odd?)              3       =>     
-  (as-checker odd?)              odd?    =not=>  
-  
+
+  (as-checker odd?)              3       =>
+  (as-checker odd?)              odd?    =not=>
+
   (fn [actual] (= 3 actual))     3       =>
   (fn [actual] (= 3 actual))     odd?    =not=>
   )
@@ -65,10 +65,10 @@
 (defn outer [n] (inner n))
 
 (tabular
-  (fact 
+  (fact
     (silent-fact
      (outer ?actual) => "expected"
-     (provided 
+     (provided
        (inner ?expected) => "expected"))
     @silent-fact:failure-count ?arrow zero?)
 

--- a/test/user/fus_config.clj
+++ b/test/user/fus_config.clj
@@ -19,7 +19,7 @@
 
 (fact "error-handling"
   (fact "can validate keys"
-    (config/validate! {:unknown-key "value"}) 
+    (config/validate! {:unknown-key "value"})
     => (throws #"not configuration keys.*:unknown-key"))
 
   (fact "can use individual validation functions"
@@ -65,29 +65,29 @@
         (fun (a-fact {:midje/name "something containing regex."})) => truthy
         (fun (a-fact {:midje/name "not a match"})) => falsey
         (fun (a-fact {})) => falsey))
-    
+
     (fact "strings are treated as substrings"
       (let [fun (config/mkfn:fact-filter-predicate ["str"])]
         (fun (a-fact {:midje/name "something str like"})) => truthy
         (fun (a-fact {:midje/name "not a match"})) => falsey
         (fun (a-fact {})) => falsey))
-    
+
     (fact "functions are applied to arguments"
       (let [fun (config/mkfn:fact-filter-predicate [(fn [meta] (= "yes" (:something meta)))])]
         (fun (a-fact {:something "yes"})) => truthy
         (fun (a-fact {:something "no"})) => falsey
         (fun (a-fact {})) => falsey))
-    
+
     (fact "multiple arguments are OR'd together"
       (let [fun (config/mkfn:fact-filter-predicate [#"foo" :valiant])]
         (fun (a-fact {:midje/name "ofoop"})) => truthy
         (fun (a-fact {:valiant true})) => truthy
         (fun (a-fact {})) => falsey))
-    
+
     (fact "filter predicates know why they were created"
       (meta (config/mkfn:fact-filter-predicate [:oddity :valiant]))
       => (contains {:created-from [:oddity :valiant]}))
-    
+
     (fact "If there are no filter arguments, the fact filter is constructed from the default"
       ;; Note that the default is not aware it works on metadata.
       (config/with-augmented-config {:fact-filter :has-this-meta-key}

--- a/test/user/fus_fact_metadata_and_quoting.clj
+++ b/test/user/fus_fact_metadata_and_quoting.clj
@@ -6,7 +6,7 @@
             [midje.data.compendium :as compendium]))
 
 
-;;; Metadata and evaluation 
+;;; Metadata and evaluation
 
 ;; Of user-supplied data, only the name is 'autoquoted'. The rest are evaled.
 ;; (Only a map, though, is a non-quoting form.)
@@ -27,7 +27,7 @@
     (:midje/namespace metadata) => (ns-name *ns*)))
 
 ;; Tabular facts turn into a fact wrapped around a number of generated facts.
-;; The metadata must be preserved 
+;; The metadata must be preserved
 (tabular name "doc string" {:meta (+ 1 2) :symbol 'symbol} (fact ?a => 1) ?a 1)
 (fact :check-only-at-load-time
   (let [metadata (meta (compendium/last-fact-checked<>))]
@@ -43,7 +43,7 @@
     (:midje/namespace metadata) => (ns-name *ns*)))
 
 ;; The same is true of metadata that's attached to the enclosed fact.
-;; The metadata must be preserved 
+;; The metadata must be preserved
 (tabular (fact name "doc string" {:meta (+ 1 2) :symbol 'symbol} ?a => 1) ?a 1)
 (fact :check-only-at-load-time
   (let [metadata (meta (compendium/last-fact-checked<>))]

--- a/test/user/fus_facts.clj
+++ b/test/user/fus_facts.clj
@@ -2,7 +2,7 @@
   (:require [midje.sweet :refer :all]
             [midje.test-util :refer :all]
             [midje.config :as config]))
-        
+
 
 (config/with-augmented-config {:visible-future true}
   (silent-fact "checkables marked 'future' don't interfere with the checking of other checkables"
@@ -11,4 +11,4 @@
     (+ 111 1) => 112)
   (note-that (fails 1 time), (fact-actual 2), (fact-expected 3)))
 
-  
+

--- a/test/user/fus_midje_forms_in_macros.clj
+++ b/test/user/fus_midje_forms_in_macros.clj
@@ -6,7 +6,7 @@
 ;; complications when a user writes macros that wrap Midje forms. This
 ;; shows that some of those complications are handled.
 
-;; This is pretty incomplete so far. 
+;; This is pretty incomplete so far.
 
                                 ;;; against-background
 

--- a/test/user/fus_nested_backgrounds.clj
+++ b/test/user/fus_nested_backgrounds.clj
@@ -10,7 +10,7 @@
 
 (silent-fact
   (against-background [(f 1) => 1]
-    (fact 
+    (fact
       (against-background [(f 2) => 2]
         (fact
           (against-background f => 3)
@@ -24,48 +24,48 @@
     (against-background (f 1) => 1)
     (f 1) => 1))
 
-(fact 
+(fact
   (against-background [(f 1) => 1]
-    (fact 
+    (fact
       (f 1) => 1)))
 
-(fact 
+(fact
   (against-background [(f 1) => 1]
     (fact
       (against-background [(f 2) => 2]
         (fact
           (+ (f 1) (f 2)) => 3)))))
 
-(fact 
+(fact
   (against-background (f 1) => 1)
-  (fact 
+  (fact
     (against-background (f 2) => 2)
     (+ (f 1) (f 2)) => 3))
 
-(fact 
+(fact
   (against-background (f 1) => 1)
-  (fact 
+  (fact
     (against-background [(f 2) => 2]
-      (fact 
+      (fact
         (+ (f 1) (f 2)) => 3))))
 
-(fact 
+(fact
   (against-background [(f 1) => 1]
-    (fact 
+    (fact
       (against-background (f 2) => 2)
       (+ (f 1) (f 2)) => 3)))
 
 
 (against-background [(f 1) => 1]
-  (fact 
+  (fact
     (against-background (f 2) => 2)
     (+ (f 1) (f 2)) => 3))
 
 
 (against-background [(f 1) => 1]
-  (fact 
+  (fact
     (against-background [(f 2) => 2]
-      (fact 
+      (fact
         (+ (f 1) (f 2)) => 3))))
 
 ;; Some of the new looser forms of against-background
@@ -73,13 +73,13 @@
 
 (fact
   (against-background [(f 1) => 1]
-    (fact 
+    (fact
       (against-background [(f 2) => 2])
       (+ (f 1) (f 2)) => 3)))
 
 (fact
   (background [(f 1) => 1])
-  (fact 
+  (fact
     (background (f 2) => 2)
     (+ (f 1) (f 2)) => 3))
 
@@ -93,7 +93,7 @@
 
   (fact
     (against-background [(f 2) => 3]
-      (fact 
+      (fact
         (against-background [(f 3) => 4])
         (+ (f 2) (f 3)) => 777))))
 (note-that fact-fails)

--- a/test/user/fus_parse_errors.clj
+++ b/test/user/fus_parse_errors.clj
@@ -36,7 +36,7 @@
     (g ..new-val..) => ..new-transformed-val..))
 (note-that parse-error-found (fact-failed-with-note #"The form before the `provided`"))
 
-(silent-fact "Misparenthesization" 
+(silent-fact "Misparenthesization"
   (f ..new-val.. => 0)
   (provided
     (g ..new-val..) => ..new-transformed-val..))
@@ -88,12 +88,12 @@
   (against-background (before :fact identity))
   1 => 2)
 (note-that parse-error-found (fact-failed-with-note #"Expected the target of `before` to be :facts, :checks, or :contents"))
-  
+
 (silent-fact
   (against-background (before :facts identity :aft identity))
   1 => 2)
 (note-that parse-error-found (fact-failed-with-note #"Expected the third argument of `before` to be :after"))
-  
+
 
 ;;; (after [:facts | :checks] <code>
 
@@ -111,8 +111,8 @@
   (against-background (after :fact identity))
   1 => 2)
 (note-that parse-error-found (fact-failed-with-note #"Expected the target of `after` to be :facts, :checks, or :contents"))
-  
-  
+
+
 ;;; (around [:facts | :checks] <code>
 
 (silent-fact
@@ -129,7 +129,7 @@
   (against-background (around :fact (let [a 1] ?form)))
   1 => 2)
 (note-that parse-error-found (fact-failed-with-note #"Expected the target of `around` to be :facts, :checks, or :contents"))
-  
+
 (silent-fact
   (against-background (around :facts (let [a 1] ?forms)))
   1 => 2)
@@ -140,7 +140,7 @@
 ;;; =====================================              `background` forms
 ;; `background` finds parse errors of its background changers"
 ;; For this first case, we check each of the types of background changers
-;; (fake, data-fake, and code-runner). In later background forms, we'll 
+;; (fake, data-fake, and code-runner). In later background forms, we'll
 ;; check fewer because they route through the same code.
 
 (capturing-failure-output  ;; a bad prerequisite
@@ -170,17 +170,17 @@
  (fact
    @fact-output => #"must look like a function call"))
 
-(capturing-failure-output 
+(capturing-failure-output
  (macroexpand-1 '(background (f 1) => 1, "1"))
  (fact
    @fact-output => #"\"1\" does not look like"))
 
-(capturing-failure-output 
+(capturing-failure-output
  (macroexpand-1 '(background ((f 1) => 1)))
  (fact
    @fact-output => #"\(\(f 1\) => 1\) does not look like"))
 
-(capturing-failure-output 
+(capturing-failure-output
  (macroexpand-1 '(background (first :facts identity)))
  (fact
    @fact-output => #"\(first :facts identity\) does not look like"))
@@ -197,13 +197,13 @@
  (macroexpand-1 '(against-background [f => 2] (fact 1 => 2)))
  (fact @fact-output => #"prerequisite must look like a function call"))
 
-(capturing-failure-output 
+(capturing-failure-output
  (macroexpand-1 '(against-background [(f 1) => 1, [1 2 3]] (fact 1 => 2)))
  (fact
    @fact-output => #"\[1 2 3\] does not look like"))
 
- 
-(capturing-failure-output 
+
+(capturing-failure-output
  (macroexpand-1 '(against-background [(f 1) => 1, (first thing)] (fact 1 => 2)))
  (fact
    @fact-output => #"\(first thing\) does not look like"))
@@ -216,12 +216,12 @@
 (fact "Nested future-facts do not trigger the complaint"
   (macroexpand-1 '(against-background [(f 1) => 1] (future-fact (+ 1 1) => 3))))
 
-  
+
 
 ;; It would be nice if it didn't complain about outer-level against-backgrounds
 ;; with nothing inside them, but that's more trouble than it's worth.
 
-(capturing-failure-output 
+(capturing-failure-output
  (macroexpand-1 '(against-background [(f 1) => 1]
                    ;; TBD
                    ))
@@ -247,7 +247,7 @@
 
   (fact "... which most likely happen by mixing the two forms"
     (against-background [(f 2) => 3]
-      (fact 
+      (fact
         (against-background [(f 3) => 4])
         (+ (f 2) (f 3)) => 7))))
 

--- a/test/user/fus_parse_exceptions.clj
+++ b/test/user/fus_parse_exceptions.clj
@@ -5,7 +5,7 @@
 
 ;;; In general, it would be nice if these could be moved over to t-parse-errors.
 
-(silent-fact "an intentional error to demonstrate the mechanism" 
+(silent-fact "an intentional error to demonstrate the mechanism"
   (fact
     (fact
       (let [a 88]

--- a/test/user/fus_prerequisites__fact_wide.clj
+++ b/test/user/fus_prerequisites__fact_wide.clj
@@ -9,7 +9,7 @@
 
 (facts
   (prerequisite (bar 1) => 1
-                (bar 88) => 88) 
+                (bar 88) => 88)
   (foo) => 3
   (provided
     (bar 2) => 2))

--- a/test/user/fus_protocols/fus_protocols.clj
+++ b/test/user/fus_protocols/fus_protocols.clj
@@ -51,7 +51,7 @@
 
 (defprotocol Addable
   (add-fields [this]))
-    
+
 (defprotocol MoreAddable
   (add-fields-and [this x]))
 

--- a/test/user/fus_threading.clj
+++ b/test/user/fus_threading.clj
@@ -15,7 +15,7 @@
          (tak (dec z) (tak-y 4) y))
     z))
 
-(def computation-tree 
+(def computation-tree
   {:one (plumbing/fnk [arg] (tak arg (tak-y 4) 20))
    :two (plumbing/fnk [arg] (tak arg (tak-y 4) 20))
    :three (plumbing/fnk [arg] (tak arg (tak-y 4) 20))

--- a/test/user/fus_within_fact_backgrounds.clj
+++ b/test/user/fus_within_fact_backgrounds.clj
@@ -26,7 +26,7 @@
   (f 2) => 2)
 
 ;;; in-fact against-background does not affect creation of source metadata
-  
+
 (fact
   (against-background (g anything) => 2)
   (f 2) => 2)


### PR DESCRIPTION
Change logs for bumped libraries:
 - [clj-time](https://github.com/clj-time/clj-time/blob/master/ChangeLog.md): Update Joda Time to 2.9.7
 - [org.clojure/math.combinatorics](https://github.com/clojure/math.combinatorics#changelog):
   - Support for clojurescript (tested with 1.9.293)
   - Dropped support for Clojure 1.2 - 1.6
- [org.clojure/tools.namespace](https://github.com/clojure/tools.namespace/blob/master/CHANGES.md#version-0211-on-19-jun-2015): Allow reader conditionals in parsed source files
 - [prismatic/plumbing](https://github.com/plumatic/plumbing/blob/master/CHANGELOG.md#054): 
   - Allow redefining keys in an inner scope, and clarify the semantics.
   - Nicer error messages for safe-get, safe-select-keys, merge-disjoint.