### PR TITLE
Fail when pre-requisite arrows are used outside the body of provided expressions

### DIFF
--- a/src/midje/parsing/1_to_explicit_form/facts.clj
+++ b/src/midje/parsing/1_to_explicit_form/facts.clj
@@ -58,6 +58,14 @@
 (defn already-expanded? [loc]
   (expanded-symbols/all (zip/node loc)))
 
+(defn prerequisite-arrow-out-of-place [loc]
+  (let [arrow      (-> loc zip/right zip/node)
+        left-expr  (-> loc zip/node)
+        right-expr (-> loc zip/right zip/right zip/node)]
+  (error/report-error left-expr
+                      "The prerequisite arrow appears outside the body of a `provided`:"
+                      (str left-expr " " arrow " " right-expr))))
+
 (defn to-explicit-form
   "Convert sweet pseudo-forms into their explicit equivalents.
    1) Arrow sequences become expect forms.
@@ -69,6 +77,9 @@
 
     recognize/start-of-checking-arrow-sequence?
     wrap-with-expect__then__at-rightmost-expect-leaf
+
+    recognize/start-of-prerequisite-arrow-sequence?
+    prerequisite-arrow-out-of-place
 
     recognize/provided?
     insert-prerequisites-into-expect-form-as-fakes

--- a/src/midje/parsing/1_to_explicit_form/prerequisites.clj
+++ b/src/midje/parsing/1_to_explicit_form/prerequisites.clj
@@ -15,10 +15,10 @@
 
 (defn prerequisite-to-fake [fake-body]
   (let [^Integer line-number (-> fake-body
-                                 (zip/seq-zip)
-                                 (zip/down )
-                                 (zip/right)
-                                 (pointer/line-number-for))
+                                 zip/seq-zip
+                                 zip/down
+                                 zip/right
+                                 pointer/line-number-for)
         fake-tag (if (recognize/metaconstant-prerequisite? fake-body)
                    `data-fake
                    `fake)]

--- a/src/midje/parsing/util/recognizing.clj
+++ b/src/midje/parsing/util/recognizing.clj
@@ -44,7 +44,15 @@
                 (symbol? (second form))
                 (expect-arrows (name (second form))))))
 
-(defn start-of-prerequisite-arrow-sequence? [form]
+(defmulti start-of-prerequisite-arrow-sequence? tree-variant)
+
+(defmethod start-of-prerequisite-arrow-sequence? :zipper [loc]
+  (boolean (and (zip/right loc)
+                (let [node (zip/node (zip/right loc))]
+                  (and (symbol? node)
+                       (fake-arrows (name node)))))))
+
+(defmethod start-of-prerequisite-arrow-sequence? :form [form]
   (boolean (and (sequential? form)
                 (symbol? (second form))
                 (fake-arrows (name (second form))))))

--- a/test/midje/t_sweet.clj
+++ b/test/midje/t_sweet.clj
@@ -30,11 +30,28 @@
 
 
 (silent-fact
- (two-numbers) => nil
- (provided
-   (number) =throws=> [1]))
-(note-that fact-fails, (fact-captured-throwable-with-message #"Right side of =throws=> should extend Throwable"))
-  
+  (two-numbers) => nil
+  (provided
+    (number) =throws=> [1]))
+(note-that fact-fails (fact-captured-throwable-with-message
+                        #"Right side of =throws=> should extend Throwable"))
+
+(silent-fact "`=throws=>` provided arrows should fail when used outside of `provided` body"
+  (inc 1) =throws=> 2)
+(note-that fact-fails (fact-failed-with-note
+                        #"The prerequisite arrow appears outside the body of a `provided`:\(inc 1\) =throws=> 2"))
+
+(silent-fact "nested `=throws=>` provided arrows should fail when used outside of `provided` body"
+  (let [x 1]
+    (inc x) =throws=> 2))
+(note-that fact-fails (fact-failed-with-note
+                        #"The prerequisite arrow appears outside the body of a `provided`:\(inc x\) =throws=> 2"))
+
+(silent-fact "`=streams=>` provided arrows should fail when used outside of `provided` body"
+  (inc 1) =streams=> 2)
+(note-that fact-fails (fact-failed-with-note
+                        #"The prerequisite arrow appears outside the body of a `provided`:\(inc 1\) =streams=> 2"))
+
 (facts "this is a doc string"
   (+ 10 10) => 20
   "this is another one"


### PR DESCRIPTION
In the past I've erroneously written:
```
(fact "check that is-num! fails on non-numeric input"
  (is-num! "bad-input") =throws=> (IllegalArgumentException. "bad-input"))
```
instead of the correct way to check throws:
```
(fact "check that is-num! fails on non-numeric input"
  (is-num! "bad-input") => (throws IllegalArgumentException "bad-input"))
```

The issue with this is that Midje disregards `=throws=>` arrows (and other prerequisite arrows) that appear outside the body of a `provided` expression. Hence, 
```
(fact "someone who doesn't understand pre-req arrows might expect this to fail"
  (is-num! 1) =throws=> (IllegalArgumentException.))
```
will always pass, no matter what we put to the left and right of `=throws=>`.

This PR ensures that `fact`s containing pre-requisite arrows outside of  `provided` bodies always fail. This will hopefully prevent people like me from writing incorrect tests that always pass.