### PR TITLE
Misc refactors and fix `empty` implementation of IPersistentCollection for Metaconstant

### DIFF
--- a/src/midje/checking/checkables.clj
+++ b/src/midje/checking/checkables.clj
@@ -1,4 +1,4 @@
-(ns ^{:doc "Core Midje functions that process expects and report on their results."} 
+(ns ^{:doc "Core Midje functions that process expects and report on their results."}
   midje.checking.checkables
   (:require [commons.clojure.core :refer :all :exclude [any?]]
             [midje.checking.core :refer :all]
@@ -29,27 +29,27 @@
 
 (defn- check-for-match [actual checkable-map]
   (let [expected (:expected-result checkable-map)]
-    (cond  (extended-= actual expected)
-           (emit/pass)
-         
-           (has-function-checker? checkable-map)
-           (emit/fail (merge (minimal-failure-map :actual-result-did-not-match-checker
-                                                  actual checkable-map)
-                             ;; TODO: It is very lame that the
-                             ;; result-function has to be called again to
-                             ;; retrieve information that extended-=
-                             ;; knows and threw away. But it's surprisingly
-                             ;; difficult to use evaluate-checking-function
-                             ;; at the top of the cond
-                             (second (evaluate-checking-function expected actual))))
-         
-           (inherently-false-map-to-record-comparison? actual expected)
-           (emit/fail (merge (minimal-failure-map :actual-result-did-not-match-expected-value actual checkable-map)
-                             (map-record-mismatch-addition actual expected)))
-         
-           :else
-           (emit/fail (assoc (minimal-failure-map :actual-result-did-not-match-expected-value actual checkable-map)
-                             :expected-result expected)))))
+    (cond (extended-= actual expected)
+          (emit/pass)
+
+          (has-function-checker? checkable-map)
+          (emit/fail (merge (minimal-failure-map :actual-result-did-not-match-checker
+                                                 actual checkable-map)
+                            ;; TODO: It is very lame that the
+                            ;; result-function has to be called again to
+                            ;; retrieve information that extended-=
+                            ;; knows and threw away. But it's surprisingly
+                            ;; difficult to use evaluate-checking-function
+                            ;; at the top of the cond
+                            (second (evaluate-checking-function expected actual))))
+
+          (inherently-false-map-to-record-comparison? actual expected)
+          (emit/fail (merge (minimal-failure-map :actual-result-did-not-match-expected-value actual checkable-map)
+                            (map-record-mismatch-addition actual expected)))
+
+          :else
+          (emit/fail (assoc (minimal-failure-map :actual-result-did-not-match-expected-value actual checkable-map)
+                            :expected-result expected)))))
 
 
 (defn- check-for-mismatch [actual checkable-map]
@@ -63,7 +63,7 @@
 
           (has-function-checker? checkable-map)
           (emit/fail (minimal-failure-map :actual-result-should-not-have-matched-checker actual checkable-map))
-        
+
           :else
           (emit/fail (minimal-failure-map :actual-result-should-not-have-matched-expected-value actual checkable-map)))))
 
@@ -80,7 +80,7 @@
 (defmethod call-count-incorrect? :fake [fake]
   (let [method (:times fake)
         count @(:call-count-atom fake)]
-    (branch-on method 
+    (branch-on method
       #(= % :default) (zero? count)
       number?         (not= method count)
       coll?           (not-any? (partial = count) method)

--- a/src/midje/data/metaconstant.clj
+++ b/src/midje/data/metaconstant.clj
@@ -72,9 +72,10 @@
   clojure.lang.Seqable
   (seq [this] (seq storage))  ; I'm unhappy to define this, but it's needed by count/empty.
 
+  clojure.lang.Counted
+  (count [this] (count storage))
+
   clojure.lang.IPersistentCollection
-  (count [this]
-         (count storage))
   (cons [this o]
         ;; (Metaconstant. (.underlying-symbol this) (cons storage o)))
         (throw (exceptions/user-error
@@ -82,7 +83,7 @@
                 "If you have a compelling need for that, please create an issue:"
                 ecosystem/issues-url)))
   (empty [this]
-         (empty? storage))
+         (empty storage))
   (equiv [this that]
          (if (or (symbol? that)
                  (= (type that) Metaconstant)

--- a/src/midje/data/metaconstant.clj
+++ b/src/midje/data/metaconstant.clj
@@ -106,13 +106,3 @@
 (defmethod print-method Metaconstant [^Metaconstant o ^java.io.Writer w]
   (print-method (.underlying-symbol o) w))
 
-
-
-
-
-
-
-
-
-
-

--- a/src/midje/data/prerequisite_state.clj
+++ b/src/midje/data/prerequisite_state.clj
@@ -27,8 +27,8 @@
 
 
 ;;; Handling mocked calls
-  
-(defmulti ^{:private true} call-handled-by-fake? (fn [function-var actual-args fake] 
+
+(defmulti ^{:private true} call-handled-by-fake? (fn [function-var actual-args fake]
                                                    (:type fake)))
 
 (defmethod call-handled-by-fake? :not-called [function-var actual-args fake]
@@ -62,7 +62,7 @@
 
 
 
-(defn- ^{:testable true } best-call-action 
+(defn- ^{:testable true} best-call-action
   "Returns a fake: when one can handle the call
    Else returns a function: from the first fake with a usable-default-function.
    Returns nil otherwise."
@@ -71,12 +71,12 @@
     (throw (apply exceptions/user-error (parse-fakes/disallowed-function-failure-lines function-var))))
   (if-let [found (find-first (partial call-handled-by-fake? function-var actual-args) fakes)]
     found
-    (when-let [fake-with-usable-default (find-first #(and (= function-var (:var %)) 
-                                                          (usable-default-function? %)) 
+    (when-let [fake-with-usable-default (find-first #(and (= function-var (:var %))
+                                                          (usable-default-function? %))
                                                     fakes)]
       (default-function fake-with-usable-default))))
 
-(defn- ^{:testable true } handle-mocked-call [function-var actual-args fakes]
+(defn- ^{:testable true} handle-mocked-call [function-var actual-args fakes]
   (macro/macrolet [(counting-nested-calls [& forms]
                `(try
                   (record-start-of-prerequisite-call)
@@ -87,14 +87,14 @@
       (branch-on action
         extended-fn?
         (apply action actual-args)
-        
+
         map?
         (do
           (swap! (:call-count-atom action) inc)
           ((:result-supplier action )))
-        
+
         :else
-        (do 
+        (do
           (emit/fail {:type :prerequisite-was-called-with-unexpected-arguments
                       :var function-var
                       :actual actual-args
@@ -108,10 +108,10 @@
 (defn- fn-fakes-binding-map [fn-fakes]
   (let [var->faker-fn (fn [the-var]
                         (-> (fn [& actual-args]
-                              (handle-mocked-call the-var actual-args fn-fakes)) 
+                              (handle-mocked-call the-var actual-args fn-fakes))
                             (vary-meta assoc :midje/faked-function true)))
         fn-fake-vars (map :var fn-fakes)]
-    (zipmap fn-fake-vars 
+    (zipmap fn-fake-vars
             (map var->faker-fn fn-fake-vars))))
 
 (defn- data-fakes-binding-map [data-fakes]
@@ -121,7 +121,7 @@
 
 (defn binding-map [fakes]
   (let [[data-fakes fn-fakes] (seq/bifurcate :data-fake fakes)]
-    (merge (fn-fakes-binding-map fn-fakes) 
+    (merge (fn-fakes-binding-map fn-fakes)
            (data-fakes-binding-map data-fakes))))
 
 (defmacro with-installed-fakes [fakes & forms]

--- a/src/midje/data/prerequisite_state.clj
+++ b/src/midje/data/prerequisite_state.clj
@@ -115,8 +115,9 @@
             (map var->faker-fn fn-fake-vars))))
 
 (defn- data-fakes-binding-map [data-fakes]
-  (apply merge-with metaconstant/merge-metaconstants (for [{:keys [var contained]} data-fakes]
-                                                       {var (Metaconstant. (pile/object-name var) contained nil)})))
+  (let [metaconstant-vars (for [{:keys [var contained]} data-fakes]
+                            {var (Metaconstant. (pile/object-name var) contained nil)})]
+    (apply merge-with metaconstant/merge-metaconstants metaconstant-vars)))
 
 (defn binding-map [fakes]
   (let [[data-fakes fn-fakes] (seq/bifurcate :data-fake fakes)]

--- a/src/midje/parsing/2_to_lexical_maps/expects.clj
+++ b/src/midje/parsing/2_to_lexical_maps/expects.clj
@@ -14,30 +14,29 @@
             [such.sequences :as seq]))
 
 
+;; TODO: Maybe this wants to be a multimethod, but I'm not sure whether the
+;; resemblance between data-fakes and regular fakes isn't too coincidental.
+(defn- expand-fake [fake]
+ (cond (first-named? fake "fake")
+       (parse-fakes/to-lexical-map-form fake)
+
+       (first-named? fake "data-fake")
+       (parse-data-fakes/to-lexical-map-form fake)
+
+       (first-named? fake "not-called")
+       (macroexpand fake)
+
+       :else
+       (do (prn "Now here's a peculiar thing to find inside a check: " fake)
+           fake)))
+
 (defn expansion [call-form arrow expected-result fakes overrides]
   (branch-on arrow
     recognize/common-check-arrow?
     (let [check (lexical-maps/checkable call-form arrow expected-result overrides)
-          expanded-fakes (map (fn [fake]
-                                 ;; TODO: Maybe this wants to be a multimethod,
-                                 ;; but I'm not sure whether the resemblance between
-                                 ;; data-fakes and regular fakes isn't too coincidental. 
-                                 (cond (first-named? fake "fake")
-                                       (parse-fakes/to-lexical-map-form fake)
-
-                                       (first-named? fake "data-fake")
-                                       (parse-data-fakes/to-lexical-map-form fake)
-
-                                       (first-named? fake "not-called")
-                                       (macroexpand fake)
-
-                                       :else
-                                       (do 
-                                         (prn "Now here's a peculiar thing to find inside a check: " fake)
-                                         fake)))
-                               fakes)]
+          expanded-fakes (map expand-fake fakes)]
       `(midje.checking.checkables/check-one ~check ~(vec expanded-fakes)))
-             
+
     recognize/macroexpansion-check-arrow?
     (let [expanded-macro `(macroexpand-1 '~call-form)
           escaped-expected-result `(quote ~expected-result)]
@@ -50,7 +49,7 @@
 
     recognize/parse-exception-arrow?
     (throw (java.lang.ClassNotFoundException. "A test asked for an exception"))
-    
+
     :else
     (throw (Error. (str "Program error: Unknown arrow form " arrow)))))
 
@@ -66,7 +65,7 @@
 (defn to-lexical-map-form [full-form]
   (apply expansion (valid-pieces full-form)))
 
-(defmacro expect 
+(defmacro expect
   {:arglists '([call-form arrow expected-result & fakes+overrides])}
   [& _]
   (to-lexical-map-form &form))

--- a/src/midje/parsing/lexical_maps.clj
+++ b/src/midje/parsing/lexical_maps.clj
@@ -79,21 +79,18 @@
                          :rhs '~(cons result overrides)}
         override-map `(hash-map ~@overrides)
         line (:line (meta call-form))
-        result `(merge
-                 {
-                  :type :fake
-                  :var ~(fnref/as-var-form fnref)
-                  :value-at-time-of-faking (if (bound? ~(fnref/as-var-form fnref))
-                                             ~(fnref/as-form-to-fetch-var-value fnref))
-                  :arglist-matcher ~(choose-mkfn-for-arglist-matcher args)
-                  :result-supplier (from-fake-maps/mkfn:result-supplier ~arrow ~result)
-                  :times :default  ; Default allows for a more attractive error in the most common case.
+        result `(merge {:type :fake
+                        :var ~(fnref/as-var-form fnref)
+                        :value-at-time-of-faking (if (bound? ~(fnref/as-var-form fnref))
+                                                   ~(fnref/as-form-to-fetch-var-value fnref))
+                        :arglist-matcher ~(choose-mkfn-for-arglist-matcher args)
+                        :result-supplier (from-fake-maps/mkfn:result-supplier ~arrow ~result)
+                        :times :default  ; Default allows for a more attractive error in the most common case.
 
-                  :position (pointer/line-number-known ~line)
-                  :namespace *ns*
-                  :call-count-atom (atom 0)
-                  :call-text-for-failures (str '~call-form)
-                 }
+                        :position (pointer/line-number-known ~line)
+                        :namespace *ns*
+                        :call-count-atom (atom 0)
+                        :call-text-for-failures (str '~call-form)}
                  ~source-details
                  ~override-map)]
     ;; pprint result
@@ -109,16 +106,14 @@
                          :rhs '~(cons contained overrides)}
         override-map `(hash-map ~@overrides)
         line (:line (meta contained))
-        result `(merge
-                 {
-                  :type :fake
-                  :data-fake true
-                  :var ~(fnref/as-var-form metaconstant)
-                  :contained ~contained
+        result `(merge {:type :fake
+                        :data-fake true
+                        :var ~(fnref/as-var-form metaconstant)
+                        :contained ~contained
 
-                  :position (pointer/line-number-known ~line)
-                  :call-count-atom (atom 1) ;; kludje
-                 }
+                        :position (pointer/line-number-known ~line)
+                        ;; kludje:
+                        :call-count-atom (atom 1)}
                  ~source-details
                  ~override-map)]
     ;; pprint result

--- a/test/as_documentation/metaconstants.clj
+++ b/test/as_documentation/metaconstants.clj
@@ -145,22 +145,8 @@
     (provided
       --mc-- =contains=> {:c 50000})))
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-;;;;
-
-;;;  Use with prerequisite functions
-
-
+(fact "Metaconstant implementations of Counted/IPersistentColleciton/Seq"
+  (prerequisites ..thing.. =contains=> {:name "basti" :counter 1})
+  (empty ..thing..) => {}
+  (count ..thing..) => 2
+  (seq ..thing..) => (list [:name "basti"] [:counter 1]))


### PR DESCRIPTION
The `Metaconstant` implementation of [`IPersistenCollection.empty`](https://github.com/clojure/clojure/blob/clojure-1.9.0-alpha17/src/jvm/clojure/lang/IPersistentCollection.java#L20) was returning a `Boolean` instead of a `IPersistentCollection` instance.

Other changes are trailing whitespace, indentation, lifting logic into helper functions, let-binding intermediate values, and a use of `such.sequences.bifurcate`

Easiest to review diff with [whitespace changes turned off](https://github.com/marick/Midje/pull/388/files?w=1)