### PR TITLE
Defer dereferences of metaconstants in function fakes

### DIFF
--- a/src/midje/data/metaconstant.clj
+++ b/src/midje/data/metaconstant.clj
@@ -1,4 +1,4 @@
-(ns ^{:doc "A notation that avoids confusion between what’s essential 
+(ns ^{:doc "A notation that avoids confusion between what’s essential
             about data and what’s accidental. A stand in for constant data."}
   midje.data.metaconstant
   (:require [midje.util.ecosystem :as ecosystem]
@@ -62,8 +62,8 @@
   (entryAt [this key]
            (find storage key))
   (assoc [this key val]
-    ;; (Metaconstant. (.underlying-symbol this) (assoc storage key val))) 
-    (throw (exceptions/user-error 
+    ;; (Metaconstant. (.underlying-symbol this) (assoc storage key val)))
+    (throw (exceptions/user-error
             (str "Metaconstants (" (.underlying-symbol this) ") can't have values assoc'd onto them.")
             "If you have a compelling need for that, please create an issue:"
             ecosystem/issues-url)))

--- a/src/midje/data/prerequisite_state.clj
+++ b/src/midje/data/prerequisite_state.clj
@@ -91,7 +91,7 @@
         map?
         (do
           (swap! (:call-count-atom action) inc)
-          ((:result-supplier action )))
+          ((:result-supplier action)))
         
         :else
         (do 

--- a/src/midje/emission/api.clj
+++ b/src/midje/emission/api.clj
@@ -5,10 +5,9 @@
             [midje.emission.clojure-test-facade :as ctf]
             [midje.emission.levels :as levels]
             [midje.emission.state :as state]
-            [midje.emission.plugins.silence :as silence]
-            [midje.util.thread-safe-var-nesting :refer [with-altered-roots]]))
+            [midje.emission.plugins.silence :as silence]))
 
-;;; Level handling
+;;; Level handling
 
 (defn level-checker [operation]
   (fn [level-name]
@@ -18,7 +17,7 @@
 (def config-at-or-above? (level-checker >=))
 (def config-above?(level-checker >))
 
-;;; Plugins
+;;; Plugins
 
 (defn load-plugin [location]
   (if (symbol? location)
@@ -32,7 +31,7 @@
       (apply function args)
       (throw (Error. (str "Your emission plugin does not define " keyword state/emission-functions))))))
 
-;;; The API proper
+;;; The API proper
 
 (defn pass []
   (state/output-counters:inc:midje-passes!)

--- a/src/midje/parsing/1_to_explicit_form/facts.clj
+++ b/src/midje/parsing/1_to_explicit_form/facts.clj
@@ -102,9 +102,9 @@
     recognize/future-fact?         (macroexpand form)
     ;; The `prerequisites` form is not supposed to be used in wrapping style.
     wrapping-background-changer?  (expand-wrapping-background-changer form)
-    recognize/expect?      (wrapping/multiwrap form (wrapping/forms-to-wrap-around :checks ))
+    recognize/expect?      (wrapping/multiwrap form (wrapping/forms-to-wrap-around :checks))
     recognize/fact?        (macroexpand form)
-    recognize/tabular?      (macroexpand form)
+    recognize/tabular?     (macroexpand form)
     sequential?  (preserve-type form (eagerly (map midjcoexpand form)))
     :else        form))
 

--- a/src/midje/parsing/1_to_explicit_form/metaconstants.clj
+++ b/src/midje/parsing/1_to_explicit_form/metaconstants.clj
@@ -4,7 +4,7 @@
   (:import midje.data.metaconstant.Metaconstant))
 
 (defn predefine-metaconstants-from-form [form]
-  (let [metaconstant-symbols (filter data/metaconstant-symbol? (tree-seq coll? seq form))]
+  (let [metaconstant-symbols (set (filter data/metaconstant-symbol? (tree-seq coll? seq form)))]
     (doseq [symbol metaconstant-symbols]
       (intern *ns* symbol (Metaconstant. symbol {} nil)))
     metaconstant-symbols))

--- a/src/midje/parsing/3_from_lexical_maps/from_fake_maps.clj
+++ b/src/midje/parsing/3_from_lexical_maps/from_fake_maps.clj
@@ -38,7 +38,9 @@
 
 (defmulti mkfn:result-supplier (fn [arrow & _] arrow))
 
-(defmethod mkfn:result-supplier => [_arrow_ result] (constantly result))
+(defmethod mkfn:result-supplier => [_arrow_ result] (fn [] (if (var? result)
+                                                             (var-get result)
+                                                             result)))
 
 (defmethod mkfn:result-supplier =streams=> [_arrow_ result-stream]
   (let [the-stream (atom result-stream)]

--- a/src/midje/parsing/3_from_lexical_maps/from_fake_maps.clj
+++ b/src/midje/parsing/3_from_lexical_maps/from_fake_maps.clj
@@ -53,7 +53,7 @@
 
 (defmethod mkfn:result-supplier =throws=> [_arrow_ throwable]
   (fn []
-    (when-not (instance? Throwable throwable) 
+    (when-not (instance? Throwable throwable)
       (throw (exceptions/user-error "Right side of =throws=> should extend Throwable.")))
     (throw throwable)))
 

--- a/src/midje/parsing/3_from_lexical_maps/from_fake_maps.clj
+++ b/src/midje/parsing/3_from_lexical_maps/from_fake_maps.clj
@@ -38,12 +38,10 @@
 
 (defmulti mkfn:result-supplier (fn [arrow & _] arrow))
 
-(defmethod mkfn:result-supplier => [_arrow_ result] (fn [] (if (var? result)
-                                                             (var-get result)
-                                                             result)))
+(defmethod mkfn:result-supplier => [_arrow_ result] result)
 
 (defmethod mkfn:result-supplier =streams=> [_arrow_ result-stream]
-  (let [the-stream (atom result-stream)]
+  (let [the-stream (atom (result-stream))]
     (fn []
       (when (empty? @the-stream)
         (throw (exceptions/user-error "Your =stream=> ran out of values.")))
@@ -51,11 +49,12 @@
         (swap! the-stream rest)
         current-result))))
 
-(defmethod mkfn:result-supplier =throws=> [_arrow_ throwable]
+(defmethod mkfn:result-supplier =throws=> [_arrow_ wrapped-throwable]
   (fn []
-    (when-not (instance? Throwable throwable)
-      (throw (exceptions/user-error "Right side of =throws=> should extend Throwable.")))
-    (throw throwable)))
+    (let [throwable (wrapped-throwable)]
+      (when-not (instance? Throwable throwable)
+        (throw (exceptions/user-error "Right side of =throws=> should extend Throwable.")))
+      (throw throwable))))
 
 (defmethod mkfn:result-supplier :default [arrow result-stream]
   (throw (exceptions/user-error "It's likely you misparenthesized your metaconstant prerequisite,"

--- a/src/midje/parsing/lexical_maps.clj
+++ b/src/midje/parsing/lexical_maps.clj
@@ -1,7 +1,6 @@
 (ns midje.parsing.lexical-maps
   "checkable maps, redefine maps, failure maps"
   (:require [commons.clojure.core :as commons]
-            [midje.data.metaconstant :as data]
             [midje.data.nested-facts :as nested-facts]
             [midje.parsing.3-from-lexical-maps.from-fake-maps :as from-fake-maps]
             [midje.parsing.util.fnref :as fnref]

--- a/src/midje/parsing/lexical_maps.clj
+++ b/src/midje/parsing/lexical_maps.clj
@@ -80,7 +80,6 @@
                          :rhs '~(cons result overrides)}
         override-map `(hash-map ~@overrides)
         line (:line (meta call-form))
-        metaconstant-var-or-val (if (data/metaconstant-symbol? result) `(var ~result) result)
         result `(merge
                  {
                   :type :fake
@@ -88,7 +87,7 @@
                   :value-at-time-of-faking (if (bound? ~(fnref/as-var-form fnref))
                                              ~(fnref/as-form-to-fetch-var-value fnref))
                   :arglist-matcher ~(choose-mkfn-for-arglist-matcher args)
-                  :result-supplier (from-fake-maps/mkfn:result-supplier ~arrow ~metaconstant-var-or-val)
+                  :result-supplier (from-fake-maps/mkfn:result-supplier ~arrow (fn [] ~result))
                   :times :default  ; Default allows for a more attractive error in the most common case.
 
                   :position (pointer/line-number-known ~line)

--- a/src/midje/parsing/lexical_maps.clj
+++ b/src/midje/parsing/lexical_maps.clj
@@ -1,6 +1,7 @@
 (ns midje.parsing.lexical-maps
   "checkable maps, redefine maps, failure maps"
   (:require [commons.clojure.core :as commons]
+            [midje.data.metaconstant :as data]
             [midje.data.nested-facts :as nested-facts]
             [midje.parsing.3-from-lexical-maps.from-fake-maps :as from-fake-maps]
             [midje.parsing.util.fnref :as fnref]
@@ -79,6 +80,7 @@
                          :rhs '~(cons result overrides)}
         override-map `(hash-map ~@overrides)
         line (:line (meta call-form))
+        metaconstant-var-or-val (if (data/metaconstant-symbol? result) `(var ~result) result)
         result `(merge
                  {
                   :type :fake
@@ -86,7 +88,7 @@
                   :value-at-time-of-faking (if (bound? ~(fnref/as-var-form fnref))
                                              ~(fnref/as-form-to-fetch-var-value fnref))
                   :arglist-matcher ~(choose-mkfn-for-arglist-matcher args)
-                  :result-supplier (from-fake-maps/mkfn:result-supplier ~arrow ~result)
+                  :result-supplier (from-fake-maps/mkfn:result-supplier ~arrow ~metaconstant-var-or-val)
                   :times :default  ; Default allows for a more attractive error in the most common case.
 
                   :position (pointer/line-number-known ~line)

--- a/test/as_documentation/metaconstants.clj
+++ b/test/as_documentation/metaconstants.clj
@@ -152,6 +152,12 @@
     (gen-doc) => ..doc..
     ..doc.. =contains=> {:header "gamma"}))
 
+(fact "Test merging of nested metaconstant that appear in data and function fakes"
+  (:header (:raw (gen-doc))) => "gamma"
+  (provided
+    (gen-doc) => {:raw ..doc..}
+    ..doc.. =contains=> {:header "gamma"}))
+
 (against-background [..doc.. =contains=> {:header "gamma"}]
   (fact "Test merging of metaconstant with against-background"
     (:header (gen-doc)) => "gamma"

--- a/test/as_documentation/metaconstants.clj
+++ b/test/as_documentation/metaconstants.clj
@@ -151,3 +151,23 @@
   (provided
     (gen-doc) => ..doc..
     ..doc.. =contains=> {:header "gamma"}))
+
+(against-background [..doc.. =contains=> {:header "gamma"}]
+  (fact "Test merging of metaconstant with against-background"
+    (:header (gen-doc)) => "gamma"
+    (provided
+      (gen-doc) => ..doc..)))
+
+(against-background [..doc..    =contains=> {:header ..header..}
+                     ..header.. =contains=> {:title "astronautas"}]
+  (future-fact "Test metaconstants that contain other metaconstants"
+    (-> (gen-doc) :header :title) => "astronautas"
+    (provided
+      (gen-doc) => ..doc..)))
+
+(future-fact "Test metaconstants that contain other metaconstants"
+  (-> (gen-doc) :header :title) => "astronautas"
+  (provided
+    (gen-doc) => ..doc..
+    ..doc..    =contains=> {:header ..header..}
+    ..header.. =contains=> {:title "astronautas"}))

--- a/test/as_documentation/metaconstants.clj
+++ b/test/as_documentation/metaconstants.clj
@@ -165,15 +165,15 @@
       (gen-doc) => ..doc..)))
 
 (against-background [..doc..    =contains=> {:header ..header..}
-                     ..header.. =contains=> {:title "astronautas"}]
+                     ..header.. =contains=> {:title "title"}]
   (future-fact "Test metaconstants that contain other metaconstants"
-    (-> (gen-doc) :header :title) => "astronautas"
+    (-> (gen-doc) :header :title) => "title"
     (provided
       (gen-doc) => ..doc..)))
 
 (future-fact "Test metaconstants that contain other metaconstants"
-  (-> (gen-doc) :header :title) => "astronautas"
+  (-> (gen-doc) :header :title) => "title"
   (provided
     (gen-doc) => ..doc..
     ..doc..    =contains=> {:header ..header..}
-    ..header.. =contains=> {:title "astronautas"}))
+    ..header.. =contains=> {:title "title"}))

--- a/test/as_documentation/metaconstants.clj
+++ b/test/as_documentation/metaconstants.clj
@@ -145,22 +145,9 @@
     (provided
       --mc-- =contains=> {:c 50000})))
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-;;;;
-
-;;;  Use with prerequisite functions
-
-
+(unfinished gen-doc)
+(fact "Test merging of metaconstant that appear in data and function fakes"
+  (:header (gen-doc)) => "gamma"
+  (provided
+    (gen-doc) => ..doc..
+    ..doc.. =contains=> {:header "gamma"}))

--- a/test/as_documentation/metaconstants.clj
+++ b/test/as_documentation/metaconstants.clj
@@ -41,7 +41,7 @@
 
 (defn choose-interesting-arg [& args]
   (first (filter interesting? args)))
-  
+
 (fact
   (choose-interesting-arg ..first.. ..second..) => ..second..
   (provided
@@ -66,7 +66,7 @@
   (provided
     (--v-- 1 2 3) => 8))
 
-    
+
 ;; Metaconstants can also be used in background prerequisites, like this:
 
 (future-fact "This is a design flaw: background and 'local' prerequisites should be merged"
@@ -177,3 +177,10 @@
     (gen-doc) => ..doc..
     ..doc..    =contains=> {:header ..header..}
     ..header.. =contains=> {:title "title"}))
+
+(future-fact "Metaconstant merging and streaming"
+  (vector (:header (gen-doc)) (:header (gen-doc))) => [1 2]
+  (provided
+    (gen-doc) =streams=> [..doc1.. ..doc2..]
+    ..doc1.. =contains=> {:header 1}
+    ..doc2.. =contains=> {:header 2}))

--- a/test/midje/data/t_metaconstant.clj
+++ b/test/midje/data/t_metaconstant.clj
@@ -180,3 +180,12 @@
           0
           ..m..) => 6)
 
+;;; Metaconstant behavior
+
+(unfinished gen-doc)
+(fact "=contains=> is evaluated once, even when referenced multiple times"
+  (identical? (gen-doc) (gen-doc)) => truthy
+  (provided
+    ..doc.. =contains=> {:header (rand)}
+    (gen-doc) => ..doc..))
+

--- a/test/midje/parsing/3_from_lexical_maps/t_from_fake_maps.clj
+++ b/test/midje/parsing/3_from_lexical_maps/t_from_fake_maps.clj
@@ -57,10 +57,10 @@ odd?                   3               falsey)
 (facts "about result suppliers used"
   "returns identity for =>"
   (let [arrow "=>"]
-    ((mkfn:result-supplier arrow [1 2 3])) => [1 2 3])
+    ((mkfn:result-supplier arrow (fn [] [1 2 3]))) => [1 2 3])
              
   "returns stream for =streams=>"
-  (let [supplier (mkfn:result-supplier "=streams=>" [1 2 3])]
+  (let [supplier (mkfn:result-supplier "=streams=>" (fn [] [1 2 3]))]
     (supplier) => 1
     (supplier) => 2
     (supplier) => 3))


### PR DESCRIPTION
Fix for https://github.com/marick/Midje/issues/159

Idea behind the fix is to, for function fake results (`(foo) => ..some-metaconstant..`), defer the dereference of variables pointing to metaconstants. These dereferences were occurring at macro-expansion time due to the use of `constantly`. By deferring to runtime, we are able to dereference these variables in scopes that have been properly manipulated by `=contains=>` data fakes.