### PR TITLE
Fix exception that ocurrs when outputting failure message for non-heterogenous data

### DIFF
--- a/src/midje/emission/plugins/util.clj
+++ b/src/midje/emission/plugins/util.clj
@@ -51,6 +51,12 @@
     [(group+format+sort comparable)
      (group+format+sort uncomparable)]))
 
+(defn- safe-sort
+  "Attempts sorting input but defaults returning the list unsorted when
+  elements are heterogeneous, and hence unsortable"
+  [xs]
+  (try (sort xs) (catch ClassCastException e xs)))
+
 (defn nested-sort
   "Sorts two nested collections for easy visual comparison.
    Sets and maps are converted to order-sets and ordered-maps."
@@ -58,13 +64,13 @@
   (letfn [(seq-in-order-by-class
             [class-name->items sort?]
             (for [[_clazz_ xs] class-name->items
-                  x (if sort? (sort xs) xs)]
+                  x (if sort? (safe-sort xs) xs)]
               x))
           (map-in-order-by-class
             [m class-name->keys sort?]
             (into (om/ordered-map)
                   (for [[_clazz_ ks] class-name->keys
-                        k (if sort? (sort ks) ks)]
+                        k (if sort? (safe-sort ks) ks)]
                     [k (nested-sort (get m k))])))]
 
     (cond (set? x)

--- a/test/midje/emission/plugins/t_util.clj
+++ b/test/midje/emission/plugins/t_util.clj
@@ -15,6 +15,8 @@
   ;; Note ordering
   (attractively-stringified-value {:b 2 :a 1}) => "{:a 1, :b 2}"
   (attractively-stringified-value #{9 6 2 7 1 3}) => "#{1 2 3 6 7 9}"
+  (read-string (attractively-stringified-value #{[1] [:a]})) => #{[1] [:a]}
+  (read-string (attractively-stringified-value {[1] "1" [:a] "a"})) => {[1] "1" [:a] "a"}
   (attractively-stringified-value (R. 1 2 3)) => #"\{:a 3, :m 2, :x 1\}::\S+\.R")
 
 

--- a/test/midje/emission/plugins/t_util.clj
+++ b/test/midje/emission/plugins/t_util.clj
@@ -15,8 +15,8 @@
   ;; Note ordering
   (attractively-stringified-value {:b 2 :a 1}) => "{:a 1, :b 2}"
   (attractively-stringified-value #{9 6 2 7 1 3}) => "#{1 2 3 6 7 9}"
-  (read-string (attractively-stringified-value #{[1] [:a]})) => #{[1] [:a]}
-  (read-string (attractively-stringified-value {[1] "1" [:a] "a"})) => {[1] "1" [:a] "a"}
+  (attractively-stringified-value #{[1] [:a]}) => (some-checker "#{[1] [:a]}" "#{[:a] [1]}")
+  (attractively-stringified-value {[1] "1" [:a] "a"}) => (some-checker "{[1] \"1\", [:a] \"a\"}" "{[:a] \"a\", [1] \"1\"}")
   (attractively-stringified-value (R. 1 2 3)) => #"\{:a 3, :m 2, :x 1\}::\S+\.R")
 
 


### PR DESCRIPTION
Fix for https://github.com/marick/Midje/issues/265

`emission.plugins.util/nested-sort` tries to be smart about what it sorts and what it doesn't sort by partitioning it by class. The issue is that `(class [1])` is the same as `(class [:a])` but you can't sort `[[1] [:a]]`.

Since this is error printing code that simply attempts to prettify the output, and implementing a correct sorter for this corner case would be a bunch of work, I've opted to default to showing unsorted output if sorting fails.