### PR TITLE
Explicitly delineate table header from body

### DIFF
--- a/src/midje/parsing/0_to_fact_form/tabular.clj
+++ b/src/midje/parsing/0_to_fact_form/tabular.clj
@@ -25,7 +25,7 @@
       (not ((set locals) s)))))
 
 (defn- headings-rows+values [table locals]
-  (if (list? (first table))
+  (if (vector? (first table))
     (list (first table) (rest table))
     (split-with (table-variable? locals) table)))
 

--- a/src/midje/parsing/0_to_fact_form/tabular.clj
+++ b/src/midje/parsing/0_to_fact_form/tabular.clj
@@ -25,7 +25,9 @@
       (not ((set locals) s)))))
 
 (defn- headings-rows+values [table locals]
-  (split-with (table-variable? locals) table))
+  (if (list? (first table))
+    (list (first table) (rest table))
+    (split-with (table-variable? locals) table)))
 
 (defn- ^{:testable true } table-binding-maps [headings-row values]
   (let [value-rows (partition (count headings-row) values)]

--- a/test/midje/parsing/0_to_fact_form/t_tabular.clj
+++ b/test/midje/parsing/0_to_fact_form/t_tabular.clj
@@ -210,7 +210,7 @@
         aaa 3]
     (tabular
       (fact (?f ?x) => ?res)
-      (?x     ?f      ?res)
+      [?x     ?f      ?res]
       aa     inc     3
       aaa    inc     4)))
 

--- a/test/midje/parsing/0_to_fact_form/t_tabular.clj
+++ b/test/midje/parsing/0_to_fact_form/t_tabular.clj
@@ -53,15 +53,6 @@
  ?a    ?b      ?result
  1     2       3)
 
-(facts
-  (let [aa  2
-        aaa 3]
-    (tabular
-      (fact (?f ?x) => ?res)
-      ?x     ?f      ?res
-      aa     inc     3
-      aaa    inc     4)))
-
 ;; Table Validation
 
 (silent-tabular
@@ -202,4 +193,24 @@
   (:integration (meta (compendium/last-fact-checked<>))) => true)
   
 
+
+(fact "can't correctly establish table headers due unbound 'aa'"
+  (let [aa  2
+        aaa 3]
+    (tabular
+      (silent-fact (?f ?x) => ?res)
+      ?x     ?f      ?res
+      aa     inc     3
+      aaa    inc     4)
+    (note-that (fact-described-as "can't correctly establish table headers due unbound 'aa'" nil nil))))
+
+
+(facts "Wrapping table headers in parenthesis helps deliniate the headers from the table body"
+  (let [aa  2
+        aaa 3]
+    (tabular
+      (fact (?f ?x) => ?res)
+      (?x     ?f      ?res)
+      aa     inc     3
+      aaa    inc     4)))
 

--- a/test/midje/parsing/0_to_fact_form/t_tabular.clj
+++ b/test/midje/parsing/0_to_fact_form/t_tabular.clj
@@ -53,6 +53,15 @@
  ?a    ?b      ?result
  1     2       3)
 
+(facts
+  (let [aa  2
+        aaa 3]
+    (tabular
+      (fact (?f ?x) => ?res)
+      ?x     ?f      ?res
+      aa     inc     3
+      aaa    inc     4)))
+
 ;; Table Validation
 
 (silent-tabular


### PR DESCRIPTION
In order to delineate between tabular headers and values, Midje uses the `table-variable?` function to collect headers until `table-variable?` returns false. This function considers unbound, non-metaconstant-like variables as table headers. This creates an issue when variable binding forms appear between the `fact`/`facts` macros and the `tabular` macro, because these bindings won't be evaluated. 

Hence, the following tabular will erroneously compute the table headers as `?x ?f ?res aa` because `aa` is unbound during macro-expansion.

```clojure
(fact "can't correctly establish table headers due unbound 'aa'"
  (let [aa  2
        aaa 3]
    (tabular
      (fact (?f ?x) => ?res)
      ?x     ?f      ?res
      aa     inc     3
      aaa    inc     4)))
```

If you reorder the columns to be `?f ?x ?res` this issue doesn't arise because the header/value splitting logic stops at `inc`.

Analyzing binding forms seemed like a prohibitive approach due to complexity, so the best solution I could come up with was to allow the user to explicitly delineate headers by wrapping them in square brackets. And continuing to allow old syntax as well.

So you can now write the following to prevent this issue:
```clojure
(fact "can't correctly establish table headers due unbound 'aa'"
  (let [aa  2
        aaa 3]
    (tabular
      (fact (?f ?x) => ?res)
      [?x     ?f      ?res]
      aa     inc     3
      aaa    inc     4)))
```

Fix for https://github.com/marick/Midje/issues/262

__Note:__ If accepted, update user docs