### PR TITLE
Allow for keyword function mocking

### DIFF
--- a/src/midje/parsing/2_to_lexical_maps/folded_fakes.clj
+++ b/src/midje/parsing/2_to_lexical_maps/folded_fakes.clj
@@ -41,23 +41,24 @@
     (and (list? x)
       (mockable-function? (first x)))))
 
-(letfn [(fake-form-funcall-arglist [[fake funcall => value & overrides :as _fake-form_]]
-          (rest funcall))]
+(defn- fake-form-funcall-arglist
+  [[fake funcall => value & overrides :as _fake-form_]]
+  (rest funcall))
 
-  (defn augment-substitutions [substitutions fake-form]
-    (let [needed-keys (filter mockable-funcall? (fake-form-funcall-arglist fake-form))]
-      ;; Note: because I like for a function's metaconstants to be
-      ;; easily mappable to the original fake, I don't make one
-      ;; unless I'm sure I need it.
-      (into substitutions (for [needed-key needed-keys
-                                :when (nil? (get substitutions needed-key))]
-                            [needed-key (metaconstant-for-form needed-key)]))))
+(defn augment-substitutions [substitutions fake-form]
+  (let [needed-keys (filter mockable-funcall? (fake-form-funcall-arglist fake-form))]
+    ;; Note: because I like for a function's metaconstants to be
+    ;; easily mappable to the original fake, I don't make one
+    ;; unless I'm sure I need it.
+    (into substitutions (for [needed-key needed-keys
+                              :when (nil? (get substitutions needed-key))]
+                          [needed-key (metaconstant-for-form needed-key)]))))
 
-  (defn folded-fake? [form]
-    (and (sequential? form)
-         (= `fake (first form))
-         (sequential? (second form))
-         (some mockable-funcall? (fake-form-funcall-arglist form)))))
+(defn folded-fake? [form]
+  (and (sequential? form)
+       (= `fake (first form))
+       (sequential? (second form))
+       (some mockable-funcall? (fake-form-funcall-arglist form))))
 
 (defn generate-fakes [substitutions overrides]
   (for [[funcall metaconstant] substitutions]

--- a/src/midje/parsing/2_to_lexical_maps/folded_fakes.clj
+++ b/src/midje/parsing/2_to_lexical_maps/folded_fakes.clj
@@ -35,6 +35,7 @@
         mockable-function? (fn [fnref]
                              (not (or (some #{fnref} special-forms)
                                       (some #{fnref} checker-makers)
+                                      (keyword? fnref)
                                       (constructor? (fnref/as-symbol fnref))
                                       (checker? (fnref/resolved-to-actual-var-object fnref)))))]
     (and (list? x)

--- a/test/midje/data/t_prerequisite_state.clj
+++ b/test/midje/data/t_prerequisite_state.clj
@@ -221,6 +221,25 @@
     (.underlying-symbol metaconstant) => 'name
     (.storage metaconstant) => {:a 1} ))
 
+(unfinished f)
+(fact "Able to mock exact keyword accessor function invocations"
+  (f (:fst {:fst 2})) => 2
+  (provided
+    (f (:fst {:fst 2})) => 2))
+
+(unfinished g)
+(defn call-g [] (g (:fst {:fst 2})))
+(fact "Able to mock exact keyword accessor invocations in nested function"
+  (call-g) => 2
+  (provided
+    (g (:fst {:fst 2})) => 2))
+
+(def my-inc inc)
+(fact "Able to mock exact nested function invocations"
+  (f (my-inc 1)) => 2
+  (provided
+    (f (my-inc 1)) => 2))
+
 
 ;;; DO NOT DELETE
 ;;; These are used to test the use of vars to fake private functions


### PR DESCRIPTION
Spent some more time looking at how `provided` handles mocks with nested expressions and realized that it isn't handling keyword functions (i.e `(:a-num {:a-num 1})`), as brought up in https://github.com/marick/Midje/issues/389.

Currently when an expression is used as an argument in a `provided` statement, Midje does not evaluate that expression, but rather only mocks function calls with those that exact expression as an argument. For example:

```clojure
(def my-inc inc)
(fact "Able to mock exact nested function invocations"
  (f (my-inc 1)) => 2
  (provided
    (f (my-inc 1)) => 2))
``` 
works, but if we do some partial evaluation in our test statement, the test fails:
```clojure
(fact "Unable to handle partial evaluation of mocked functions"
  (f 2) => 2
  (provided
    (f (my-inc 1)) => 2))
```

This is a trade-off in test framework expressiveness that makes sense.

When we apply this to keyword functions, Midje fails [here](https://github.com/marick/Midje/blob/master/src/midje/parsing/2_to_lexical_maps/folded_fakes.clj#L38-L39) due to the fact that the [fnref classification function](https://github.com/marick/Midje/blob/master/src/midje/parsing/util/fnref.clj#L7-L11) doesn't handle keywords.
This prevents us from doing things like
```clojure
(unfinished f)
(fact "Able to mock exact keyword accessor function invocations"
  (f (:fst {:fst 2})) => 2
  (provided
    (f (:fst {:fst 2})) => 2))
```

Addresses https://github.com/marick/Midje/issues/362 and https://github.com/marick/Midje/issues/281