### PR TITLE
Fix tests that fail on :autotest reload

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -22,7 +22,7 @@
              :test-libs {:dependencies [[prismatic/plumbing "0.5.4"]]}
              :1.7 [:test-libs {:dependencies [[org.clojure/clojure "1.7.0"]]}]
              :1.8 [:test-libs {:dependencies [[org.clojure/clojure "1.8.0"]]}]
-             :1.9 [:test-libs {:dependencies [[org.clojure/clojure "1.9.0-alpha13"]]}]
+             :1.9 [:test-libs {:dependencies [[org.clojure/clojure "1.9.0-alpha17"]]}]
              ;; The following profile can be used to check that `lein with-profile`
              ;; profiles are obeyed. Note that profile `:test-paths` *add on* to the
              ;; defaults.

--- a/src/midje/doc.clj
+++ b/src/midje/doc.clj
@@ -69,7 +69,7 @@
   (recheck-fact :print-nothing) ; Check silently (but produce true/false).
   (rcf)                         ; Synonym for above.
 
-  Note: facts with `:check-only-at-load-time`metadata do not get
+  Note: facts with `:check-only-at-load-time` metadata do not get
   stored for rechecking.
 
   ----- Forgetting facts

--- a/src/midje/emission/clojure_test_facade.clj
+++ b/src/midje/emission/clojure_test_facade.clj
@@ -30,7 +30,7 @@
                             [])]
     (binding [ct/*test-out* (java.io.StringWriter.)]
       (assoc (apply ct/run-tests namespaces-to-run)
-             :lines (->> ct/*test-out* .toString str/split-lines (remove empty?))))))
+             :lines (->> ct/*test-out* .toString str/split-lines)))))
 
 (defn forget-failures
   "This can only be used within the dynamic scope of run-tests."

--- a/src/midje/emission/clojure_test_facade.clj
+++ b/src/midje/emission/clojure_test_facade.clj
@@ -30,7 +30,7 @@
                             [])]
     (binding [ct/*test-out* (java.io.StringWriter.)]
       (assoc (apply ct/run-tests namespaces-to-run)
-             :lines (-> ct/*test-out* .toString str/split-lines)))))
+             :lines (->> ct/*test-out* .toString str/split-lines (remove empty?))))))
 
 (defn forget-failures
   "This can only be used within the dynamic scope of run-tests."

--- a/src/midje/emission/plugins/junit.clj
+++ b/src/midje/emission/plugins/junit.clj
@@ -65,7 +65,7 @@
 
 (defn process-fact [fact]
   (let [elapsed (/ (time/in-millis (time/interval (-> fact :attrs :start-time)
-                                                 (-> fact :attrs :stop-time)))
+                                                  (-> fact :attrs :stop-time)))
                    1000.0)
         dissoc-times (fn [attrs] (-> attrs
                                     (dissoc :start-time)

--- a/src/midje/parsing/1_to_explicit_form/parse_background.clj
+++ b/src/midje/parsing/1_to_explicit_form/parse_background.clj
@@ -263,6 +263,11 @@
                   commons/union
                   (set (map name symbols))))
 
+(defn remove-midje-fact-symbols [symbols]
+  (alter-var-root #'at-least-one-string-with-this-name-must-be-present
+                  commons/difference
+                  (set (map name symbols))))
+
 ;; It would be better to check symbols like `midje/fact` than the string "fact";
 ;; however, all the symbols are duplicated in midje.sweet and midje.repl (because they
 ;; can be loaded independently). It seems too convoluted to list everything twice, and the

--- a/test/midje/emission/plugins/t_junit.clj
+++ b/test/midje/emission/plugins/t_junit.clj
@@ -23,7 +23,8 @@
       (prerequisites
        (#'plugin/log-fn) => #(println %)
        (#'plugin/clear-file (contains "test-namespace")) => nil :times 1
-       (#'plugin/clear-file (contains "other-namespace")) => nil :times 1)
+       (#'plugin/clear-file (contains "other-namespace")) => nil :times 1
+       (#'plugin/clear-file (contains "placeholder-to-reset-namespace")) => nil :times 1)
 
       (innocuously :possible-new-namespace 'test-namespace)
       => (contains "<testsuite name='test-namespace'")
@@ -33,7 +34,8 @@
       ;; entering a different namespace must close previous one
       (innocuously :possible-new-namespace 'other-namespace)
       ;; FIXME: nicer test for 'both strings present'
-      => (contains (str "</testsuite>" "\n" "<testsuite name='other-namespace'")))
+      => (contains (str "</testsuite>" "\n" "<testsuite name='other-namespace'"))
+      (innocuously :possible-new-namespace 'placeholder-to-reset-namespace))
 
 ;; FIXME: this statefullnes is ugly and hard to test.
 ;; if this fact runs standalone, the :possible-new-namespace will try to clear
@@ -42,10 +44,12 @@
 (fact "Closing a fact stream closes testsuite"
       (prerequisites
        (#'plugin/clear-file (contains "test-namespace")) => nil
+       (#'plugin/clear-file (contains "placeholder-to-reset-namespace")) => nil :times 1
        (#'plugin/log-fn) => #(println %))
       (innocuously :possible-new-namespace 'test-namespace)
       (innocuously :finishing-fact-stream {} {})
-      => (contains "</testsuite>"))
+      => (contains "</testsuite>")
+      (innocuously :possible-new-namespace 'placeholder-to-reset-namespace))
 
 (fact "pass produces a <testcase> tag"
   (plugin/starting-to-check-fact test-fact)

--- a/test/midje/emission/plugins/t_junit.clj
+++ b/test/midje/emission/plugins/t_junit.clj
@@ -8,7 +8,7 @@
             [midje.emission.plugins.default-failure-lines :as failure-lines]))
 
 (defn innocuously [key & args]
-  (config/with-augmented-config {:emitter 'midje.emission.plugins.junit
+  (config/with-augmented-config {:emitter     'midje.emission.plugins.junit
                                  :print-level :print-facts}
     (captured-output (apply (key plugin/emission-map) args))))
 
@@ -16,8 +16,8 @@
   (with-meta (fn[]) {:midje/name "named" :midje/description "desc" :midje/namespace "blah"}))
 
 (def test-failure-map
- {:type :some-prerequisites-were-called-the-wrong-number-of-times,
-   :namespace "midje.emission.plugins.t-junit"})
+ {:type      :some-prerequisites-were-called-the-wrong-number-of-times,
+  :namespace "midje.emission.plugins.t-junit"})
 
 (fact "Entering a new namespace opens a file."
       (prerequisites

--- a/test/midje/emission/t_clojure_test_facade.clj
+++ b/test/midje/emission/t_clojure_test_facade.clj
@@ -33,9 +33,9 @@
   (fact
     (:test result) => 2
     (:fail result) => 1
-    (nth (:lines result) 1) => #"FAIL in.*a-clojure-test-fail"
-    (nth (:lines result) 2) => #"expected"
-    (nth (:lines result) 3) => #"actual"
+    (nth (:lines result) 1) => #"FAIL.*in.*a-clojure-test-fail"
+    (nth (:lines result) 3) => #"expected"
+    (nth (:lines result) 4) => #"actual"
     (take-last 2 (:lines result)) => ["Ran 2 tests containing 2 assertions."
                                       "1 failures, 0 errors."]))
 

--- a/test/midje/emission/t_clojure_test_facade.clj
+++ b/test/midje/emission/t_clojure_test_facade.clj
@@ -40,3 +40,4 @@
                                       "1 failures, 0 errors."]))
 
 (ns-unmap *ns* 'a-clojure-test-fail) ; so as not to see failure when test rerun.
+(ns-unmap *ns* 'a-clojure-test-pass) ; so as not to see success when test rerun.

--- a/test/midje/emission/t_clojure_test_facade.clj
+++ b/test/midje/emission/t_clojure_test_facade.clj
@@ -11,7 +11,8 @@
     :check-only-at-load-time
     (:test result) => 0
     (:fail result) => 0
-    (:lines result) => ["Ran 0 tests containing 0 assertions."
+    (:lines result) => [""
+                        "Ran 0 tests containing 0 assertions."
                         "0 failures, 0 errors."]))
 
 (clojure.test/deftest a-clojure-test-pass
@@ -21,7 +22,8 @@
   (fact
     (:test result) => 1
     (:fail result) => 0
-    (:lines result) => ["Ran 1 tests containing 1 assertions."
+    (:lines result) => [""
+                        "Ran 1 tests containing 1 assertions."
                         "0 failures, 0 errors."]))
 
 (clojure.test/deftest a-clojure-test-fail
@@ -32,8 +34,6 @@
     (:test result) => 2
     (:fail result) => 1
     (nth (:lines result) 1) => #"FAIL.*in.*a-clojure-test-fail"
-    (nth (:lines result) 2) => #"expected"
-    (nth (:lines result) 4) => #"actual"
     (take-last 2 (:lines result)) => ["Ran 2 tests containing 2 assertions."
                                       "1 failures, 0 errors."]))
 

--- a/test/midje/emission/t_clojure_test_facade.clj
+++ b/test/midje/emission/t_clojure_test_facade.clj
@@ -11,8 +11,7 @@
     :check-only-at-load-time
     (:test result) => 0
     (:fail result) => 0
-    (:lines result) => ["",
-                        "Ran 0 tests containing 0 assertions."
+    (:lines result) => ["Ran 0 tests containing 0 assertions."
                         "0 failures, 0 errors."]))
 
 (clojure.test/deftest a-clojure-test-pass
@@ -22,8 +21,7 @@
   (fact
     (:test result) => 1
     (:fail result) => 0
-    (:lines result) => ["",
-                        "Ran 1 tests containing 1 assertions."
+    (:lines result) => ["Ran 1 tests containing 1 assertions."
                         "0 failures, 0 errors."]))
 
 (clojure.test/deftest a-clojure-test-fail
@@ -34,7 +32,7 @@
     (:test result) => 2
     (:fail result) => 1
     (nth (:lines result) 1) => #"FAIL.*in.*a-clojure-test-fail"
-    (nth (:lines result) 3) => #"expected"
+    (nth (:lines result) 2) => #"expected"
     (nth (:lines result) 4) => #"actual"
     (take-last 2 (:lines result)) => ["Ran 2 tests containing 2 assertions."
                                       "1 failures, 0 errors."]))

--- a/test/midje/t_repl.clj
+++ b/test/midje/t_repl.clj
@@ -517,9 +517,11 @@
   (set (keys (autotest-options))) => (contains #{:interval :files}))
 
 (fact "options can be set"
-  (:interval (autotest-options)) =not=> 832
-  (set-autotest-option! :interval 832)
-  (:interval (autotest-options)) => 832)
+  (let [old-interval (:interval (autotest-options))]
+    (:interval (autotest-options)) =not=> 832
+    (set-autotest-option! :interval 832)
+    (:interval (autotest-options)) => 832
+    (set-autotest-option! :interval old-interval)))
 
 (fact "autotest"
   (against-background (autotest-options) => ..options..

--- a/test/user/fus_midje_forms_in_macros.clj
+++ b/test/user/fus_midje_forms_in_macros.clj
@@ -1,6 +1,7 @@
 (ns user.fus-midje-forms-in-macros
   (:require [midje.sweet :refer :all]
-            [midje.test-util :refer :all]))
+            [midje.test-util :refer :all]
+            [midje.parsing.1-to-explicit-form.parse-background :as parse-background]))
 
 ;; Because of the way that Midje does its parsing, there are
 ;; complications when a user writes macros that wrap Midje forms. This
@@ -46,6 +47,7 @@
 (add-midje-fact-symbols '[hidden-fact])
 (with-state-changes []
   (hidden-fact 1 => 1))
+(parse-background/remove-midje-fact-symbols '[hidden-fact])
 
 ;;; Here is an old bug
 


### PR DESCRIPTION
Some tests manipulate state and test those manipulations. If you load those tests via `lein midje :autotest` and rerun them, their state isn't correctly reset, so they fail.

This PR resets the state for those tests so that they continue to pass. 

Each commit (disregarding readability commits) should correspond to a test fix.