### PR TITLE
Fix `just` checker when expected result has maps that share keys

### DIFF
--- a/src/midje/checking/checkers/collection.clj
+++ b/src/midje/checking/checkers/collection.clj
@@ -63,20 +63,35 @@
 
 (defn standardized-arguments
   "Reduce arguments to standard forms so there are fewer combinations to
- consider. Also blow up for some incompatible forms."
+  consider. Also blow up for some incompatible forms."
   [actual expected looseness]
   (compatibility-check actual expected looseness)
   (cond
-   (and (sequential? actual) (set? expected))                  [actual (vec expected) (union looseness #{:in-any-order })]
-   (and (sequential? actual) (right-hand-singleton? expected)) [actual [expected] (union looseness #{:in-any-order })]
-   (sequential? actual)                                        [actual expected looseness]
-   (and (map? actual) (map? expected))  [actual expected looseness]
-   (map? actual)                        [actual (into {} expected) looseness]
-   (set? actual)                        (recur (vec actual) expected looseness-modifiers)
+   (and (sequential? actual) (set? expected))
+   [actual (vec expected) (union looseness #{:in-any-order})]
+
+   (and (sequential? actual) (right-hand-singleton? expected))
+   [actual [expected] (union looseness #{:in-any-order})]
+
+   (sequential? actual)
+   [actual expected looseness]
+
+   (and (map? actual) (map? expected))
+   [actual expected looseness]
+
+   (map? actual)
+   [actual (into {} expected) looseness]
+
+   (set? actual)
+   (recur (vec actual) expected looseness-modifiers)
+
    (and (string? actual)
         (not (string? expected))
-        (not (regex? expected)))        (recur (vec actual) expected looseness-modifiers)
-        :else                                [actual expected looseness]))
+        (not (regex? expected)))
+   (recur (vec actual) expected looseness-modifiers)
+
+   :else
+   [actual expected looseness]))
 
 (defn match? [actual expected looseness]
   (let [comparison (compare-results actual expected looseness)]

--- a/src/midje/checking/checkers/collection.clj
+++ b/src/midje/checking/checkers/collection.clj
@@ -67,31 +67,31 @@
   [actual expected looseness]
   (compatibility-check actual expected looseness)
   (cond
-   (and (sequential? actual) (set? expected))
-   [actual (vec expected) (union looseness #{:in-any-order})]
+    (and (sequential? actual) (set? expected))
+    [actual (vec expected) (union looseness #{:in-any-order})]
 
-   (and (sequential? actual) (right-hand-singleton? expected))
-   [actual [expected] (union looseness #{:in-any-order})]
+    (and (sequential? actual) (right-hand-singleton? expected))
+    [actual [expected] (union looseness #{:in-any-order})]
 
-   (sequential? actual)
-   [actual expected looseness]
+    (sequential? actual)
+    [actual expected looseness]
 
-   (and (map? actual) (map? expected))
-   [actual expected looseness]
+    (and (map? actual) (map? expected))
+    [actual expected looseness]
 
-   (map? actual)
-   [actual (into {} expected) looseness]
+    (and (map? actual) (= (count (keys (into {} expected))) (count expected)))
+    [actual (into {} expected) looseness]
 
-   (set? actual)
-   (recur (vec actual) expected looseness-modifiers)
+    (set? actual)
+    (recur (vec actual) expected looseness-modifiers)
 
-   (and (string? actual)
-        (not (string? expected))
-        (not (regex? expected)))
-   (recur (vec actual) expected looseness-modifiers)
+    (and (string? actual)
+         (not (string? expected))
+         (not (regex? expected)))
+    (recur (vec actual) expected looseness-modifiers)
 
-   :else
-   [actual expected looseness]))
+    :else
+    [actual expected looseness]))
 
 (defn match? [actual expected looseness]
   (let [comparison (compare-results actual expected looseness)]
@@ -222,7 +222,7 @@ just is also useful if you don't care about order:
   [1 3 2] => (just   [1 2 3] :in-any-order)
   [1 3 2] => (just  #{1 2 3})"
     :arglists '([expected]
-                  [expected looseness])}
+                [expected looseness])}
   just (container-checker-maker 'just
                                 (fn [actual expected looseness]
                                   (let [[actual expected looseness] (standardized-arguments actual expected looseness)]

--- a/test/midje/checking/checkers/t_collection.clj
+++ b/test/midje/checking/checkers/t_collection.clj
@@ -278,6 +278,12 @@
  ( (contains (AB. 1 2)) {:a 1 :b 2}) => falsey
  ( (just {:top (just (AB. 1 2))}) {:top {:a 1, :b 2}}) => falsey
 
+ {:a 2}   => (contains {:a 2})
+ {:a 2}   => (contains [{:a 2}])
+ [{:a 2}] => (contains [{:a 2}])
+ {:a 2} =not=> (contains {:a 1} {:a 2})
+ {:a 2} =not=> (contains [{:a 1} {:a 2}] :in-any-order)
+ {:a 2} =not=> (contains [{:a 2} {:a 1}] :in-any-order)
  ( (contains {:a 1, :b 2, :c 2}) {:a 1, :b 2}) => falsey
  ( (contains {:a 1, :c 2}) {:a 1, :b 2}) => falsey
  ( (contains {:a 1, :b 'not-2}) {:a 1, :b 2}) => falsey
@@ -292,12 +298,12 @@
  (  (just {:a even?}) {:a 1}) => falsey
  (  (just {:a even?}) {nil 1}) => falsey
 
- ((just {:a 1}) {:a 1}) => truthy
- ((just [{:a 1}]) {:a 1}) => falsey
- ((just [{:a 1} {:b 2}]) {:a 1}) => falsey
- ((just [{:a 1} {:b 2}] :in-any-order) {:a 1}) => falsey
- ((just [{:a 1} {:a 2}]) {:a 2}) => falsey
- ((just [{:a 1} {:a 2}] :in-any-order) {:a 2}) => falsey
+ {:a 1} => (just {:a 1})
+ {:a 1} =not=> (just [{:a 1} {:b 2}])
+ {:a 1} =not=> (just [{:a 1} {:b 2}] :in-any-order)
+ {:a 2} =not=> (just [{:a 1} {:a 2}])
+ [{:a 1} {:a 2}] => (just [{:a 1} {:a 2}])
+ {:a 2} =not=> (just [{:a 1} {:a 2}] :in-any-order)
 
  ;; extended-equality isn't recursive, so...
  ;; ... while this works without lower-level annotation

--- a/test/midje/checking/checkers/t_collection.clj
+++ b/test/midje/checking/checkers/t_collection.clj
@@ -292,6 +292,13 @@
  (  (just {:a even?}) {:a 1}) => falsey
  (  (just {:a even?}) {nil 1}) => falsey
 
+ ((just {:a 1}) {:a 1}) => truthy
+ ((just [{:a 1}]) {:a 1}) => falsey
+ ((just [{:a 1} {:b 2}]) {:a 1}) => falsey
+ ((just [{:a 1} {:b 2}] :in-any-order) {:a 1}) => falsey
+ ((just [{:a 1} {:a 2}]) {:a 2}) => falsey
+ ((just [{:a 1} {:a 2}] :in-any-order) {:a 2}) => falsey
+
  ;; extended-equality isn't recursive, so...
  ;; ... while this works without lower-level annotation
  {:actual-found ["12" "1" "123"] } => (contains {:actual-found ["12" "1" "123"] })


### PR DESCRIPTION
Fix for https://github.com/marick/Midje/issues/348

`just` and `contains` checkers have some tricky logic that normalizes the `expected` and `actual` arguments. In a specific corner case, when `actual` is a map and `expected` is a list of maps, the normalization logic tries to turn `expected` into a map. This can lead to loss of information due to key merging, and hence incorrect check results.

For example, the following `fact` erroneously passes:
```clojure
(fact
  {:a 2} => (just [{:a 1} {:a 2}])
; `just` will turn ` [{:a 1} {:a 2}]` into {:a 2} via `(into {} expected)`
```
Such merging in the context of `just` can never result in a `true` result, so my solution is to prevent such normalization, leaving `expected` as a list, hence causing the check to fail.

The same applies to `contains` because if `actual` is a map and `expected` is a list of maps, any merging means that the `actual` map can never contain the entries (which will have duplicates) in the `expected` list.

The last usage of `standardized-arguments` is for `has-prefix`, which doesn't have sensible semantics when `actual` is a map, so we don't need to worry about it.