### PR TITLE
Fail when =contains=> targets a non-map value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Change Log
-This project adheres to [Semantic Versioning](http://semver.org/).       
+This project adheres to [Semantic Versioning](http://semver.org/).
 See [here](http://keepachangelog.com/) for the change log format.
+
+## [1.9.0-alpha9] - 2017-08-03
+- Fail when `=contains=>` targets a non-map value, which has unclear semantics
 
 ## [1.9.0-alpha8] - 2017-07-04
 Fixed issues:
@@ -43,7 +46,7 @@ Fixed issues:
 - NOTE NOTE NOTE: Previous should be documented before 1.9.0 is released.
 - This is the last version compatible with Specter 0.9.X
 
-## [1.8.3] 
+## [1.8.3]
 - Bump to newer versions of dependencies
 
 ## [1.8.2]

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject midje "1.9.0-alpha8"
+(defproject midje "1.9.0-alpha9"
   :description "A TDD library for Clojure that supports top-down ('mockish') TDD, encourages readable tests, provides a smooth migration path from clojure.test, balances abstraction and concreteness, and strives for graciousness."
   :url "https://github.com/marick/Midje"
   :pedantic? :warn

--- a/src/midje/parsing/2_to_lexical_maps/data_fakes.clj
+++ b/src/midje/parsing/2_to_lexical_maps/data_fakes.clj
@@ -11,7 +11,11 @@
   (cond (not (metaconstant/metaconstant-symbol? metaconstant))
         (error/report-error form
                             (cl-format nil "In `~A ~A ~A`, ~A is not a metaconstant."
-                                       metaconstant arrow contained metaconstant)))
+                                       metaconstant arrow contained metaconstant))
+        (not (map? contained))
+        (error/report-error form
+                            (cl-format nil "In `~A ~A ~A`, ~A is not a map."
+                                       metaconstant arrow contained contained)))
   [metaconstant arrow contained overrides])
 
 (def assert-valid! valid-pieces)

--- a/test/midje/data/t_metaconstant.clj
+++ b/test/midje/data/t_metaconstant.clj
@@ -189,3 +189,16 @@
     ..doc.. =contains=> {:header (rand)}
     (gen-doc) => ..doc..))
 
+(silent-fact
+  (first (gen-doc)) => "list"
+  (provided
+    (gen-doc) => ..doc..
+    ..doc.. =contains=> ["list" "contains" "not" "supported"]))
+(note-that fact-fails, (fact-failed-with-note #".*is not a map"))
+
+(silent-fact
+  (first (gen-doc)) => \s
+  (provided
+    (gen-doc) => ..doc..
+    ..doc.. =contains=> "should fail"))
+(note-that fact-fails, (fact-failed-with-note #".*is not a map"))

--- a/test/midje/parsing/1_to_explicit_form/t_metaconstants.clj
+++ b/test/midje/parsing/1_to_explicit_form/t_metaconstants.clj
@@ -35,7 +35,7 @@
   (let [c 'c]
     (concer ...source...) => "abc"
     (provided
-      ...source... =contains=> '{:a a, :b b}
+      ...source... =contains=> {:a 'a, :b 'b}
       ...source... =contains=> {:c c})))
 
 


### PR DESCRIPTION
Ran into a bug when using `..some-metaconstant.. =contains=> [1 2 3]` only to realize that `=contains=>` was never meant to be used with lists, or non-map values for that matter.

For example, [the current metaconstant merging logic](https://github.com/marick/Midje/blob/master/src/midje/data/metaconstant.clj#L104), which runs when `..mc.. =contains=> ...` appears twice in `against-background`/`provided` forms, doesn't work with non-map values.

Also, what would be the semantics of the following?:
```clojure
(fact 
  (first (g)) => ????
  (provided 
    (g) => ..result..
    ..result.. =contains=> [1 2]
    ..result.. =contains=> [3 4]))
```

One could argue that letting `=contains=>` operate over sets would be useful and have clear semantics, but I'm in favor of restricting the capabilities of `=contains=>` because it is already a bit confusing to use.


The approach this PR takes to addressing the problem is to change the behavior of `=contains=>` from:
```clojure
(use 'midje.repl)

(defn get-metaconstant-storage-str [m]
  (with-out-str (print (.storage m))))

(unfinished a-func)
(fact "example showing that you used to be able to store anything in a metaconstant"
  (get-metaconstant-storage-str (a-func)) => "[1]"
  (provided
    (a-func) => ..result.. 
    ..result.. =contains=> [1]))
```
to
```clojure
(fact
  (get-metaconstant-storage-str (a-func)) => "[1]"
  (provided
    (a-func) => ..result.. 
    ..result.. =contains=> [1]))

FAIL at (form-init935422476386958100.clj:2)
    Midje could not understand something you wrote: 
        In `..result.. =contains=> [1]`, [1] is not a map.
```