### PR TITLE
Runtime check to see if a =contains=> target variable resolves to map

### DIFF
--- a/src/midje/data/metaconstant.clj
+++ b/src/midje/data/metaconstant.clj
@@ -28,6 +28,11 @@
   (if-let [[variant body] (evaluate-comparison-potential x)]
     (str variant body variant)))
 
+(defn- report-error [top-line]
+  (exceptions/user-error
+   top-line
+   "If you have a compelling case for equality, please create an issue:"
+   ecosystem/issues-url))
 
 ;;; Metaconstant proper
 
@@ -98,6 +103,11 @@
   clojure.lang.IObj
   (meta [this] meta-data)
   (withMeta [this m] (Metaconstant. underlying-symbol storage m)))
+
+(defn metaconstant [underlying-symbol ^clojure.lang.Associative storage meta-data]
+  (when (not (map? storage))
+    (throw (report-error (str "Metaconstants (" underlying-symbol ") can't represent non-map values " (pr-str storage) "."))))
+  (Metaconstant. underlying-symbol storage meta-data))
 
 (defn merge-metaconstants [^Metaconstant mc1 ^Metaconstant mc2]
   (Metaconstant. (.underlying-symbol mc1)

--- a/src/midje/data/metaconstant.clj
+++ b/src/midje/data/metaconstant.clj
@@ -68,10 +68,7 @@
            (find storage key))
   (assoc [this key val]
     ;; (Metaconstant. (.underlying-symbol this) (assoc storage key val)))
-    (throw (exceptions/user-error
-            (str "Metaconstants (" (.underlying-symbol this) ") can't have values assoc'd onto them.")
-            "If you have a compelling need for that, please create an issue:"
-            ecosystem/issues-url)))
+    (throw (report-error (str "Metaconstants (" (.underlying-symbol this) ") can't have values assoc'd onto them."))))
 
   ;; Next two interfaces are extended by Associative.
   clojure.lang.Seqable
@@ -83,10 +80,7 @@
   clojure.lang.IPersistentCollection
   (cons [this o]
         ;; (Metaconstant. (.underlying-symbol this) (cons storage o)))
-        (throw (exceptions/user-error
-                (str "Metaconstants (" (.underlying-symbol this) ") can't have values added onto them.")
-                "If you have a compelling need for that, please create an issue:"
-                ecosystem/issues-url)))
+        (throw (report-error (str "Metaconstants (" (.underlying-symbol this) ") can't have values added onto them."))))
   (empty [this]
          (empty storage))
   (equiv [this that]
@@ -94,10 +88,9 @@
                  (= (type that) Metaconstant)
                  (= that unbound-marker))
            (.equals this that)
-           (throw (exceptions/user-error
-                   (str "Metaconstants (" (.underlying-symbol this) ") can't be compared for equality with " (pr-str that) ".")
-                   "If you have a compelling case for equality, please create an issue:"
-                   ecosystem/issues-url))))
+           (throw
+             (report-error (str "Metaconstants (" (.underlying-symbol this) ") can't be compared for equality with "
+                                (pr-str that) ".")))))
 
   ;; Interface that provide meta support.
   clojure.lang.IObj

--- a/src/midje/data/prerequisite_state.clj
+++ b/src/midje/data/prerequisite_state.clj
@@ -4,7 +4,7 @@
             [commons.clojure.core :refer :all :exclude [any?]]
             [midje.checking.core :refer :all]
             [midje.config :as config]
-            [midje.data.metaconstant :as metaconstant]
+            [midje.data.metaconstant :as mc]
             [midje.emission.api :as emit]
             [midje.emission.deprecation :refer [deprecate]]
             [midje.parsing.arrow-symbols :refer :all]
@@ -116,8 +116,8 @@
 
 (defn- data-fakes-binding-map [data-fakes]
   (let [metaconstant-vars (for [{:keys [var contained]} data-fakes]
-                            {var (Metaconstant. (pile/object-name var) contained nil)})]
-    (apply merge-with metaconstant/merge-metaconstants metaconstant-vars)))
+                            {var (mc/metaconstant (pile/object-name var) contained nil)})]
+    (apply merge-with mc/merge-metaconstants metaconstant-vars)))
 
 (defn binding-map [fakes]
   (let [[data-fakes fn-fakes] (seq/bifurcate :data-fake fakes)]

--- a/src/midje/data/prerequisite_state.clj
+++ b/src/midje/data/prerequisite_state.clj
@@ -13,8 +13,7 @@
             [midje.util.pile :as pile]
             [midje.util.thread-safe-var-nesting :refer [with-altered-roots]]
             [such.maps :as map]
-            [such.sequences :as seq])
-  (:import midje.data.metaconstant.Metaconstant))
+            [such.sequences :as seq]))
 
 
 ;;; Questions to ask of fakes // accessors

--- a/src/midje/parsing/1_to_explicit_form/metaconstants.clj
+++ b/src/midje/parsing/1_to_explicit_form/metaconstants.clj
@@ -1,11 +1,10 @@
 (ns ^{:doc "Transforming code in a way that produces metaconstants"}
   midje.parsing.1-to-explicit-form.metaconstants
-  (:require [midje.data.metaconstant :as data])
-  (:import midje.data.metaconstant.Metaconstant))
+  (:require [midje.data.metaconstant :as data]))
 
 (defn predefine-metaconstants-from-form [form]
   (let [metaconstant-symbols (set (filter data/metaconstant-symbol? (tree-seq coll? seq form)))]
     (doseq [symbol metaconstant-symbols]
-      (intern *ns* symbol (Metaconstant. symbol {} nil)))
+      (intern *ns* symbol (data/metaconstant symbol {} nil)))
     metaconstant-symbols))
 

--- a/src/midje/parsing/2_to_lexical_maps/data_fakes.clj
+++ b/src/midje/parsing/2_to_lexical_maps/data_fakes.clj
@@ -7,12 +7,18 @@
             [midje.parsing.util.core :refer :all]
             [midje.parsing.util.error-handling :as error]))
 
+(defn- not-map-or-symbol?
+  "Check if a value isn't a map or symbol; symbols are allowed because they may
+  resolve to maps at runtime"
+  [x]
+  (not (or (map? x) (symbol? x))))
+
 (defn valid-pieces [[_data-fake_ metaconstant arrow contained & overrides :as form]]
   (cond (not (metaconstant/metaconstant-symbol? metaconstant))
         (error/report-error form
                             (cl-format nil "In `~A ~A ~A`, ~A is not a metaconstant."
                                        metaconstant arrow contained metaconstant))
-        (not (map? contained))
+        (not-map-or-symbol? contained)
         (error/report-error form
                             (cl-format nil "In `~A ~A ~A`, ~A is not a map."
                                        metaconstant arrow contained contained)))

--- a/test/midje/data/t_metaconstant.clj
+++ b/test/midje/data/t_metaconstant.clj
@@ -189,6 +189,25 @@
     ..doc.. =contains=> {:header (rand)}
     (gen-doc) => ..doc..))
 
+(let [some-map {:header 50}]
+  (fact "=contains=> pointing to a map var works"
+    (:header (gen-doc)) => 50
+    (provided
+      ..doc.. =contains=> some-map
+      (gen-doc) => ..doc..)))
+
+(def contains-exception (atom nil))
+(try
+  (let [some-list (list 1 2 3)]
+    (fact "=contains=> pointing to a non-map var fails at runtime"
+      (first (gen-doc)) => irrelevant
+      (provided
+        ..doc.. =contains=> some-list
+        (gen-doc) => ..doc..)))
+  (catch Error e (reset! contains-exception e)))
+(fact "assert that the contains check above failed"
+  @contains-exception =not=> nil)
+
 (silent-fact
   (first (gen-doc)) => "list"
   (provided

--- a/test/midje/data/t_metaconstant.clj
+++ b/test/midje/data/t_metaconstant.clj
@@ -3,8 +3,7 @@
             [midje
              [sweet :refer :all]
              [test-util :refer :all]]
-            [clojure.zip :as zip])
-  (:import midje.data.metaconstant.Metaconstant))
+            [clojure.zip :as zip]))
 
 ;;; Metaconstant symbols
 
@@ -44,67 +43,67 @@
 
 
 
-;;; Metaconstants
+;;; metaconstant
 
-(let [mc (Metaconstant. '..name.. {} nil)]
-  (fact "Metaconstants print as their name"
+(let [mc (metaconstant '..name.. {} nil)]
+  (fact "metaconstant print as their name"
     (str mc) => "..name.."
     (pr-str mc) => "..name.."))
 
-(fact "Metaconstants implement Named"
-  (name (Metaconstant. '..name. {} nil)) => "..name.")
+(fact "metaconstant implement Named"
+  (name (metaconstant '..name. {} nil)) => "..name.")
 
-(fact "Metaconstants are equal if their names are *comparable*."
+(fact "metaconstant are equal if their names are *comparable*."
   (fact "equal names are comparable"
-    (Metaconstant.    '...name... {} nil) => (Metaconstant. '...name... {} nil)
-    (Metaconstant.    '...name... {} nil) =not=> (Metaconstant. '...other... {} nil))
+    (metaconstant    '...name... {} nil) => (metaconstant '...name... {} nil)
+    (metaconstant    '...name... {} nil) =not=> (metaconstant '...other... {} nil))
 
   (fact "but so are names that have a different number of dots or dashes"
-    (Metaconstant.    '...name... {} nil) => (Metaconstant. '.name. {} nil)
-    (Metaconstant.    '---name- {} nil) => (Metaconstant. '-name--- {} nil))
+    (metaconstant    '...name... {} nil) => (metaconstant '.name. {} nil)
+    (metaconstant    '---name- {} nil) => (metaconstant '-name--- {} nil))
 
   (fact "However, dot-names are not equal to dash-names"
-    (Metaconstant.    '...name... {} nil) =not=> (Metaconstant. '---name--- {} nil))
+    (metaconstant    '...name... {} nil) =not=> (metaconstant '---name--- {} nil))
 
   (fact "values are irrelevant"
-    (Metaconstant.    '...name... {:key "value"} nil) => (Metaconstant. '...name... {:key "not-value"} nil)
-    (Metaconstant.  '...NAME... {:key "value"} nil) =not=> (Metaconstant. '...name... {:key "value"} nil))
+    (metaconstant    '...name... {:key "value"} nil) => (metaconstant '...name... {:key "not-value"} nil)
+    (metaconstant  '...NAME... {:key "value"} nil) =not=> (metaconstant '...name... {:key "value"} nil))
 
-  (fact "Metaconstants are equal to symbols with a comparable name"
-    (= (Metaconstant. '...name... {} nil) '.name.) => truthy
-    (= (Metaconstant. '...name... {} nil) '...not-name...) => falsey
+  (fact "metaconstant are equal to symbols with a comparable name"
+    (= (metaconstant '...name... {} nil) '.name.) => truthy
+    (= (metaconstant '...name... {} nil) '...not-name...) => falsey
 
     (fact "which means they can be compared to quoted lists"
-      (list 'a (Metaconstant. '...name... {} nil)) => '(a ...name.)
+      (list 'a (metaconstant '...name... {} nil)) => '(a ...name.)
       ;; The following works because Clojure shifts Associates to left-hand-side
-      '(a ...name...) => (list 'a (Metaconstant. '...name... {} nil)))))
+      '(a ...name...) => (list 'a (metaconstant '...name... {} nil)))))
 
-(fact "Metaconstants implement ILookup"
-  (let [mc (Metaconstant. 'm {:key "value"} nil)]
+(fact "metaconstant implement ILookup"
+  (let [mc (metaconstant 'm {:key "value"} nil)]
     (:key mc) => "value"
     (:not-key mc "default") => "default"
     "And let's allow the other type of map lookup"
     (mc :key) => "value"
     (mc :not-key "default") => "default"))
 
-(fact "Metaconstants implement Associative lookup"
-  (let [mc (Metaconstant. 'm {:key "value"} nil)]
+(fact "metaconstant implement Associative lookup"
+  (let [mc (metaconstant 'm {:key "value"} nil)]
     (contains? mc :key) => truthy
     (contains? mc :not-key) => falsey
 
     (find mc :key) => [:key "value"]))
 
 (fact "Associate extends some of Seqable and IPersistentCollection"
-  (let [mc (Metaconstant. 'm {:key "value"} nil)]
+  (let [mc (metaconstant 'm {:key "value"} nil)]
     (count mc) => 1
     (empty? mc) => falsey
     (.equiv mc mc) => truthy))
 
-(facts "Metaconstants implement IObj"
-  (let [mc (Metaconstant. 'm {} nil)]
+(facts "metaconstant implement IObj"
+  (let [mc (metaconstant 'm {} nil)]
     (meta mc) => nil
     (.meta (with-meta mc {:key "value"})) => {:key "value"})
-  (let [mc (Metaconstant. 'm {} {:key "value"})]
+  (let [mc (metaconstant 'm {} {:key "value"})]
     (meta mc) => {:key "value"}
     (.meta (with-meta mc {:key "other"})) => {:key "other"}))
 

--- a/test/midje/data/t_metaconstant.clj
+++ b/test/midje/data/t_metaconstant.clj
@@ -195,17 +195,16 @@
       ..doc.. =contains=> some-map
       (gen-doc) => ..doc..)))
 
-(def contains-exception (atom nil))
-(try
+(defn exec-runtime-failing-fact []
   (let [some-list (list 1 2 3)]
     (fact "=contains=> pointing to a non-map var fails at runtime"
       (first (gen-doc)) => irrelevant
       (provided
         ..doc.. =contains=> some-list
-        (gen-doc) => ..doc..)))
-  (catch Error e (reset! contains-exception e)))
+        (gen-doc) => ..doc..))))
+
 (fact "assert that the contains check above failed"
-  @contains-exception =not=> nil)
+  (exec-runtime-failing-fact) => (throws Error))
 
 (silent-fact
   (first (gen-doc)) => "list"

--- a/test/midje/data/t_prerequisite_state.clj
+++ b/test/midje/data/t_prerequisite_state.clj
@@ -9,8 +9,7 @@
             [midje.parsing.2-to-lexical-maps.data-fakes :refer [data-fake]]
             [midje.util :refer :all]
             [midje.config :as config]
-            [such.sequences :as seq])
-  (:import midje.data.metaconstant.Metaconstant))
+            [such.sequences :as seq]))
 
 (expose-testables midje.data.prerequisite-state)
 

--- a/test/midje/parsing/3_from_lexical_maps/t_from_fake_maps.clj
+++ b/test/midje/parsing/3_from_lexical_maps/t_from_fake_maps.clj
@@ -5,8 +5,7 @@
             [midje.parsing.3-from-lexical-maps.from-fake-maps :refer :all]
             [midje.test-util :refer :all]
             [midje.util :refer :all]
-            [midje.config :as config])
-  (:import midje.data.metaconstant.Metaconstant))
+            [midje.config :as config]))
 
 (expose-testables midje.data.prerequisite-state)
 


### PR DESCRIPTION
Follow-up to https://github.com/marick/Midje/pull/399 ensuring that variables are taken into account.

For example, the following failed after the https://github.com/marick/Midje/pull/399 changes:
```clojure
(let [some-map {:header 50}]
  (fact "=contains=> pointing to a map var works"
    (:header (gen-doc)) => 50
    (provided
      ..doc.. =contains=> some-map
      (gen-doc) => ..doc..)))
```

Thanks to @rafaeldff for the catch