### PR TITLE
Fix stacktrace of actual/expected outputs after pretty-print change

### DIFF
--- a/src/midje/config.clj
+++ b/src/midje/config.clj
@@ -22,11 +22,10 @@
 (defn running-in-repl? []
   started-in-repl?)
 
-
-
 (defonce ^{:dynamic true}
   *config* {:print-level :print-normally
             :colorize (not (ecosystem/on-windows?))
+            :pretty-print true
             :visible-deprecation true
             :visible-future true
             :visible-failure-namespace false

--- a/src/midje/doc.clj
+++ b/src/midje/doc.clj
@@ -282,6 +282,9 @@
   :print-level                  ; Verbosity of printing.
                                 ; See `(doc midje-print-levels)`.
 
+  :pretty-print                 ; Use formatting and color in test output
+                                ; Default: true
+
   :visible-deprecation          ; Whether information about deprecated
                                 ; features or functions is printed.
                                 ; Default: true.

--- a/src/midje/emission/plugins/default_failure_lines.clj
+++ b/src/midje/emission/plugins/default_failure_lines.clj
@@ -47,30 +47,30 @@
   (let [expected (:expected-result m)
         actual (:actual m)]
     (list
-     (str "    Expected:\n" (attractively-stringified-value (:expected-result m)))
-     (str "      Actual:\n" (attractively-stringified-value (:actual m)))
+     (str "Expected:\n" (attractively-stringified-value (:expected-result m)))
+     (str "Actual:\n" (attractively-stringified-value (:actual m)))
      (diffs [actual expected])
      (notes m))))
 
 (defmethod messy-lines :actual-result-should-not-have-matched-expected-value [m]
   (list
-   (str "    Expected: Anything BUT " (attractively-stringified-value (:expected-result m)))
-   (str "      Actual: " (attractively-stringified-value (:actual m)))
+   (str "Expected: Anything BUT\n" (attractively-stringified-value (:expected-result m)))
+   (str "Actual:\n" (attractively-stringified-value (:actual m)))
    (notes m)))
 
 (defmethod messy-lines :actual-result-did-not-match-checker [m]
     (list
       "Actual result did not agree with the checking function."
-      (str "        Actual result: " (attractively-stringified-value (:actual m)))
-      (str "    Checking function: " (:expected-result-form m))
+      (str "Actual result:\n" (attractively-stringified-value (:actual m)))
+      (str "Checking function: " (:expected-result-form m))
       (intermediate-results m)
       (notes m)))
 
 (defmethod messy-lines :actual-result-should-not-have-matched-checker [m]
     (list
       "Actual result was NOT supposed to agree with the checking function."
-      (str "        Actual result: " (attractively-stringified-value (:actual m)))
-      (str "    Checking function: " (:expected-result-form m))))
+      (str "Actual result:\n" (attractively-stringified-value (:actual m)))
+      (str "Checking function: " (:expected-result-form m))))
 
 
 (defmethod messy-lines :some-prerequisites-were-called-the-wrong-number-of-times [m]

--- a/src/midje/emission/plugins/default_failure_lines.clj
+++ b/src/midje/emission/plugins/default_failure_lines.clj
@@ -33,7 +33,7 @@
                                                         (concat (map #(str "  " %) (rest s))))))))))))
 
           (prefix [[first & more]]
-            (cons (str "       Diffs: " first)
+            (cons (str "Diffs: " first)
                   (map #(str "              " %) more)))]
     (cond (or (every? sequential? pair)
               (every? map? pair)

--- a/src/midje/emission/plugins/util.clj
+++ b/src/midje/emission/plugins/util.clj
@@ -141,15 +141,15 @@
         : a nicely printed stack trace
         : maps and sets sorted by key."
   [v]
-  (let [raw-str (cond
-                  (fn? v)                           (function-name v)
-                  (exception/captured-throwable? v) (exception/friendly-stacktrace v)
-                  (record? v)                       (str (sorted-if-appropriate v) "::" (record-name v))
-                  :else                             (sorted-if-appropriate v))]
-    (puget/cprint-str raw-str {:print-handlers {Metaconstant puget/pr-handler}
-                               :print-fallback :pretty
-                               :seq-limit      10
-                               :map-delimiter  ""})))
+  (if (exception/captured-throwable? v)
+    (exception/friendly-stacktrace v)
+    (let [raw-str (cond (fn? v)     (function-name v)
+                        (record? v) (str (sorted-if-appropriate v) "::" (record-name v))
+                        :else       (sorted-if-appropriate v))]
+      (puget/cprint-str raw-str {:print-handlers {Metaconstant puget/pr-handler}
+                                 :print-fallback :pretty
+                                 :seq-limit      10
+                                 :map-delimiter  ""}))))
 
 (defn format-nested-descriptions
   "Takes vector like [\"about cars\" nil \"sports cars are fast\"] and returns non-nils joined with -'s

--- a/src/midje/emission/plugins/util.clj
+++ b/src/midje/emission/plugins/util.clj
@@ -146,10 +146,17 @@
     (let [raw-str (cond (fn? v)     (function-name v)
                         (record? v) (str (sorted-if-appropriate v) "::" (record-name v))
                         :else       (sorted-if-appropriate v))]
-      (puget/cprint-str raw-str {:print-handlers {Metaconstant puget/pr-handler}
-                                 :print-fallback :pretty
-                                 :seq-limit      10
-                                 :map-delimiter  ""}))))
+      (cond
+        (config/choice :pretty-print)
+        (puget/cprint-str raw-str {:print-handlers {Metaconstant puget/pr-handler}
+                                   :print-fallback :pretty
+                                   :seq-limit      10
+                                   :map-delimiter  ""})
+        (string? raw-str)
+        raw-str
+
+        :else
+        (pr-str raw-str)))))
 
 (defn format-nested-descriptions
   "Takes vector like [\"about cars\" nil \"sports cars are fast\"] and returns non-nils joined with -'s

--- a/src/midje/util/exceptions.clj
+++ b/src/midje/util/exceptions.clj
@@ -29,7 +29,7 @@
 (declare caused-by-lines)
 
 (defn- main-exception-lines [ex prefix]
-  (cons (str ex)
+  (cons (str prefix ex)
       (map #(str prefix %)
         (without-midje-or-clojure-strings (stacktrace-as-strings ex)))))
 
@@ -58,7 +58,7 @@
   ICapturedThrowable
   (throwable [this] ex)
   (friendly-stacktrace [this]
-    (join line-separator (friendly-exception-lines (throwable this) "              "))))
+    (join line-separator (friendly-exception-lines (throwable this) "  "))))
 
 (defn captured-throwable [ex]
   (CapturedThrowable. ex))

--- a/src/midje/util/exceptions.clj
+++ b/src/midje/util/exceptions.clj
@@ -29,7 +29,7 @@
 (declare caused-by-lines)
 
 (defn- main-exception-lines [ex prefix]
-  (cons (str prefix ex)
+  (cons (str ex)
       (map #(str prefix %)
         (without-midje-or-clojure-strings (stacktrace-as-strings ex)))))
 

--- a/test/as_documentation/tabular_facts.clj
+++ b/test/as_documentation/tabular_facts.clj
@@ -33,12 +33,12 @@
    @fact-output => (contains "                           ?b 2")
    @fact-output => (contains "                           ?result 3333]")
    (strip-ansi-coloring @fact-output) => (contains "Expected:\n3333")
-   (strip-ansi-coloring @fact-output) => (contains "  Actual:\n3")
+   (strip-ansi-coloring @fact-output) => (contains "Actual:\n3")
    @fact-output => (contains "With table substitutions: [?a 1")
    @fact-output => (contains "                           ?b 0")
    @fact-output => (contains "                           ?result 11]")
    (strip-ansi-coloring @fact-output) => (contains "Expected:\n11")
-   (strip-ansi-coloring @fact-output) => (contains "  Actual:\n1")))
+   (strip-ansi-coloring @fact-output) => (contains "Actual:\n1")))
 
 
 ;;;                                     More about doc Strings and Metadata
@@ -83,7 +83,7 @@
    @fact-output => (contains "With table substitutions: [?a 1")
    @fact-output => (contains "                           ?b 1]")
    (strip-ansi-coloring @fact-output) => (contains "Expected:\n1")
-   (strip-ansi-coloring @fact-output) => (contains "  Actual:\n2")))
+   (strip-ansi-coloring @fact-output) => (contains "Actual:\n2")))
 
 ;; It's natural to think of substituting values and expressions,
 ;; but you can substitute anything, such as Midje arrows.

--- a/test/midje/emission/plugins/t_default_end_to_end.clj
+++ b/test/midje/emission/plugins/t_default_end_to_end.clj
@@ -15,8 +15,10 @@
  (fact (+ 1 1) =not=> 2)
  (fact
    @fact-output => #"FAIL"
-   (strip-ansi-coloring @fact-output) => #"Expected: Anything BUT 2"
-   (strip-ansi-coloring @fact-output) => #"Actual:\s+2"))
+   (strip-ansi-coloring @fact-output) => #"Expected: Anything BUT"
+   (strip-ansi-coloring @fact-output) => #"2"
+   (strip-ansi-coloring @fact-output) => #"Actual:"
+   (strip-ansi-coloring @fact-output) => #"2"))
 
 (capturing-failure-output
  (fact (+ 1 1) => odd?)

--- a/test/midje/emission/plugins/t_default_failure_lines.clj
+++ b/test/midje/emission/plugins/t_default_failure_lines.clj
@@ -16,13 +16,13 @@
       (map strip-ansi-coloring
            (summarize {:type :actual-result-did-not-match-expected-value
                        :expected-result 1, :actual 2}))
-      => (just "notice" #"\s+Expected:\n1", #"\s+Actual:\n2")
+      => (just "notice" #"Expected:\n1", #"Actual:\n2")
 
       ;; in general...
       (map strip-ansi-coloring
            (summarize {:type :actual-result-did-not-match-expected-value
                        :expected-result ..expected.. :actual ..actual..}))
-      => (just "notice" #"\s+Expected:\nEEE", #"\s+Actual:\nAAA")
+      => (just "notice" #"Expected:\nEEE", #"Actual:\nAAA")
       (provided
         (util/attractively-stringified-value ..expected..) => 'EEE
         (util/attractively-stringified-value ..actual..) => 'AAA))
@@ -31,13 +31,13 @@
       (map strip-ansi-coloring
            (summarize {:type :actual-result-should-not-have-matched-expected-value
                        :expected-result 2, :actual 2}))
-      => (just "notice" #"\s+Expected: Anything BUT 2", #"\s+Actual: 2")
+      => (just "notice" #"Expected: Anything BUT\n2", #"Actual:\n2")
 
       ;; in general...
       (map strip-ansi-coloring
            (summarize {:type :actual-result-should-not-have-matched-expected-value
                        :expected-result ..expected.. :actual ..actual..}))
-      => (just "notice" #"\s+Expected: Anything BUT EEE", #"\s+Actual: AAA")
+      => (just "notice" #"Expected: Anything BUT\nEEE", #"Actual:\nAAA")
       (provided
         (util/attractively-stringified-value ..expected..) => 'EEE
         (util/attractively-stringified-value ..actual..) => 'AAA))
@@ -63,7 +63,7 @@
          (summarize {:type :actual-result-did-not-match-checker
                      :actual 2, :expected-result-form 'odd?}))
     => (just "notice" "Actual result did not agree with the checking function."
-             #"\s+Actual result: 2" #"\s+Checking function: odd")
+             #"Actual result:\n2" #"Checking function: odd")
 
     (fact "can supply intermediate results"
     (map strip-ansi-coloring
@@ -71,8 +71,8 @@
                      :actual 2, :expected-result-form 'checker
                      :intermediate-results '[[(f 1) "3"] [(f 2) 3]]}))
       => (just "notice" "Actual result did not agree with the checking function."
-               #"\s+Actual result: 2"
-               #"\s+Checking function: checker"
+               #"Actual result:\n2"
+               #"Checking function: checker"
                #"During checking, these intermediate values were seen:"
                (contains "(f 1) => \"3\"")
                (contains "(f 2) => 3")))
@@ -83,8 +83,8 @@
                        :actual 2, :expected-result-form 'checker
                        :notes ["note 1" "note 2"]}))
       => (just "notice" "Actual result did not agree with the checking function."
-               #"\s+Actual result: 2"
-               #"\s+Checking function: checker"
+               #"Actual result:\n2"
+               #"Checking function: checker"
                #"The checker said this about the reason:"
                #"note 1"
                #"note 2"))
@@ -96,8 +96,8 @@
                        :expected-result-form 'checker
                        :intermediate-results '[[(f 2) #{15 3 7 2}]]}))
       => (just "notice" "Actual result did not agree with the checking function."
-               #"\s+Actual result: \{:a 5 :d 7 :f 6 :p 3 :r 4 :z 2\}"
-               #"\s+Checking function: checker"
+               #"Actual result:\n\{:a 5 :d 7 :f 6 :p 3 :r 4 :z 2\}"
+               #"Checking function: checker"
                #"During checking, these intermediate values were seen:"
                (contains "(f 2) => #{2 3 7 15}")))
 
@@ -107,8 +107,8 @@
                        :actual {:z 2 :p 3 :r 4 :a 5 :f 6 :d 7}
                        :expected-result-form '(collection 3)}))
       => (just "notice" "Actual result was NOT supposed to agree with the checking function."
-               #"\s+Actual result: \{:a 5 :d 7 :f 6 :p 3 :r 4 :z 2\}"
-               #"\s+Checking function: \(collection 3\)")))
+               #"Actual result:\n\{:a 5 :d 7 :f 6 :p 3 :r 4 :z 2\}"
+               #"Checking function: \(collection 3\)")))
 
   (fact "prerequisites"
     (fact "called with unexpected arguments"

--- a/test/midje/emission/plugins/t_util.clj
+++ b/test/midje/emission/plugins/t_util.clj
@@ -26,6 +26,14 @@
     (attractively-stringified-value {[1] "1" [:a] "a"})) => (some-checker "{[1] \"1\" [:a] \"a\"}" "{[:a] \"a\" [1] \"1\"}")
   (attractively-stringified-value (R. 1 2 3)) => #"\{:a 3, :m 2, :x 1\}::\S+\.R")
 
+(facts "Configuring :pretty-print settings"
+  (fact "You can turn off fancy pretty printing"
+    (config/with-augmented-config {:pretty-print false}
+      (attractively-stringified-value {:b 2 :a 1}) => "{:a 1, :b 2}"))
+  (fact "By default pretty-printing is on, and will print formatted, colored output"
+    (test-util/strip-ansi-coloring
+      (attractively-stringified-value {:b 2 :a 1})) => "{:a 1 :b 2}"
+    (attractively-stringified-value {:b 2 :a 1}) =not=> "{:a 1 :b 2}"))
 
 (tabular "descriptions harvested from nested facts can be formatted as '-' separated"
   (fact


### PR DESCRIPTION
After https://github.com/marick/Midje/pull/403 stacktraces looked like this:
```
Actual:
"java.lang.ArithmeticException: Non-terminating decimal expansion; no exact representable decimal result.\n              logic$eval72838$_brackets__72843$fn__7
2844.invoke(logic.clj:36)\n              logic$eval72838$_brackets__72843.invoke(logic.clj:31)\n              logic_test$eval73253$fn__73254$fn__73255$fn__7326
8$fn__73269$fn__73270.invoke(logic_test.clj:27)\n              logic_test$eval73253$fn__73254$fn__73255$fn__73268$fn__73269.invoke(logic_test.clj:5)\n         
     logic_test$eval73253$fn__73254$fn__73255$fn__73268.invoke(logic_test.clj:5)\n              logic_test$eval73253$fn__73254$fn__73255.invoke(logic_test.clj:
5)\n              logic_test$eval73253$fn__73254.invoke(logic_test.clj:5)\n              logic_test$eval73253.invokeStatic(logic_test.clj:5)\n              log
ic_test$eval73253.invoke(logic_test.clj:5)"  
```

This PR fixes this regression to output like:
```                                                                                                                                              
Actual:                                                                                                                                                        
java.lang.ArithmeticException: Non-terminating decimal expansion; no exact representable decimal result.                                                     
  logic$eval41768$_brackets__41773$fn__41774.invoke(logic.clj:36)                                                                                              
  logic$eval41768$_brackets__41773.invoke(logic.clj:31)                                                                                                        
  logic_test$eval72317$fn__72318$fn__72319$fn__72332$fn__72333$fn__72334.invoke(logic_test.clj:27)                                                             
  logic_test$eval72317$fn__72318$fn__72319$fn__72332$fn__72333.invoke(logic_test.clj:5)                                                                        
  logic_test$eval72317$fn__72318$fn__72319$fn__72332.invoke(logic_test.clj:5)                                                                                  
  logic_test$eval72317$fn__72318$fn__72319.invoke(logic_test.clj:5)                                                                                            
  logic_test$eval72317$fn__72318.invoke(logic_test.clj:5)                                                                                                      
  logic_test$eval72317.invokeStatic(logic_test.clj:5)                                                                                                          
  logic_test$eval72317.invoke(logic_test.clj:5)   
```

**:pretty-print**
Also adds the `:pretty-print` configuration, which is set to `true` by default.
This controls the usage of a pretty printer for outputting test results. For example

```
user=> (fact x => {})

FAIL at (form-init8899591318111329910.clj:2)
Expected:
{}
Actual:
{:partial-prerequisites false
 :pretty-print false
 :print-level :print-namespaces
 :run-clojure-test true
 :visible-deprecation false
 :visible-failure-namespace false
 :visible-future true}
Diffs: map contained keys: #{:visible-deprecation :run-clojure-test :visible-failure-namespace :print-level :partial-prerequisites :visible-future :pretty-print}, but not expected.

user=> (midje.config/change-defaults :pretty-print false)
{:check-after-creation true
 :check-recorder #<Fn@ab00bc7 midje.config/eval24620[fn]>
  ...
 :pretty-print false
  ...}

user=> (fact x => {})

FAIL at (form-init8899591318111329910.clj:2)
Expected:
{}
Actual:
{:partial-prerequisites false, :pretty-print false, :print-level :print-namespaces, :run-clojure-test true, :visible-deprecation false, :visible-failure-namespace false, :visible-future true}
Diffs: map contained keys: #{:visible-deprecation :run-clojure-test :visible-failure-namespace :print-level :partial-prerequisites :visible-future :pretty-print}, but not expected.
```
