### PR TITLE
Make tests launched from repl pass w/ nrepl middleware

### DIFF
--- a/test/implementation/util/fim_exceptions.clj
+++ b/test/implementation/util/fim_exceptions.clj
@@ -43,9 +43,12 @@
   (let [strings ["swank.core$eval"]]
     (without-midje-or-clojure-strings strings) => []))
 
+(defn- remove-nrepl-lines [lines]
+  (remove #(re-find #">>>refactor_nrepl" %) lines))
+
 (fact
   ;; since midje lines are omitted, there's not much we can check.
-  (let [lines (friendly-exception-lines (Error. "message") ">>>")]
+  (let [lines (remove-nrepl-lines (friendly-exception-lines (Error. "message") ">>>"))]
     (first lines) => #"Error.*message"
     (re-find #"^>>>" (first lines)) => falsey
     (count (keep #(re-find #">>>implementation.util.fim_exceptions" %) (rest lines))) => (count (rest lines))))
@@ -74,7 +77,7 @@
   (ex-info "Exception with a cause chain 2 deep" {:info "2 deep"} (call-nested-exception)))
 
 (fact "exceptions with nested 'cause' data more than 1 level deep, shows all 'cause' stacktraces"
-  (let [lines (friendly-exception-lines double-nested-exception ">>>")]
+  (let [lines (remove-nrepl-lines (friendly-exception-lines double-nested-exception ">>>"))]
     (clojure.string/join "&" lines) => #"(?x)^clojure.lang.ExceptionInfo:\ Exception\ with\ a\ cause\ chain\ 2\ deep\ \{:info\ \"2\ deep\"\}
                                              &
                                              &>>>Caused\ by:\ clojure.lang.ExceptionInfo:\ Found\ a\ NPE\ \{:info\ \"wrapped\ throw\ of\ an\ NPE\"\}

--- a/test/midje/emission/t_deprecation.clj
+++ b/test/midje/emission/t_deprecation.clj
@@ -33,6 +33,3 @@
   (config/with-augmented-config {:visible-deprecation false}
     (without-previous-deprecations
      (with-out-str (deprecate "test message")) => "")))
-
-
-


### PR DESCRIPTION
If you have `refactor-nrepl` in your repl plugins and you try to launch midje's tests via:
```
lein repl
> (use 'midje.repl)
> (load-facts)
```
Then a [few](https://github.com/marick/Midje/blob/e8674a3279ea365ec5e22bb311925861e11c6374/test/implementation/util/fim_exceptions.clj#L51) [tests](https://github.com/marick/Midje/blob/e8674a3279ea365ec5e22bb311925861e11c6374/test/implementation/util/fim_exceptions.clj#L78) fail because `>>>refactor_nrepl.ns.slam.hound.regrow$wrap_clojure_repl$fn__15083.doInvoke(regrow.clj:18)` shows up in the error stack trace.

I adjusted the tests to ignore lines that start with `refactor_nrepl`

An alternative solution would be to remove stack trace lines starting with `refactor_nrepl` from the printed stack trace [here](https://github.com/marick/Midje/blob/e8674a3279ea365ec5e22bb311925861e11c6374/src/midje/util/exceptions.clj#L26-L27), which felt a bit cludgy, but might go better with the current code which strives to exclude non-useful error info.