### PR TITLE
WIP: Use tools.namespace to reload namespaces

### DIFF
--- a/src/midje/data/project_state.clj
+++ b/src/midje/data/project_state.clj
@@ -115,11 +115,10 @@
 
 (defn mkfn:scan-and-react [options scanner]
   (fn []
-    (swap! state-tracker-atom
-           #(let [state (with-fresh-copy-of-dependency-map %)
-                  new-tracker (apply scanner state (:files options))]
-              (react-to-tracker! new-tracker options)
-              (prepare-for-next-scan new-tracker)))))
+    (let [state       (with-fresh-copy-of-dependency-map @state-tracker-atom)
+          new-tracker (apply scanner state (:files options))]
+      (react-to-tracker! new-tracker options)
+      (reset! state-tracker-atom (prepare-for-next-scan new-tracker)))))
 
 
 (defn mkfn:react-to-changes [options]

--- a/src/midje/data/project_state.clj
+++ b/src/midje/data/project_state.clj
@@ -3,6 +3,7 @@
   (:require [clj-time.local :as time]
             [clojure.java.io :as io]
             [clojure.set]
+            [clojure.tools.namespace.dependency :as nsdependency]
             [clojure.tools.namespace.repl :as nsrepl]
             [clojure.tools.namespace.dir :as nsdir]
             [clojure.tools.namespace.track :as nstrack]
@@ -110,7 +111,7 @@
   "Records must be recreated if the protocols that they implement are reloaded."
   [state]
   (if (get state deps-key)
-    (update-in state [deps-key] clojure.tools.namespace.dependency/map->MapDependencyGraph)
+    (update-in state [deps-key] nsdependency/map->MapDependencyGraph)
     state))
 
 (defn mkfn:scan-and-react [options scanner]

--- a/src/midje/repl.clj
+++ b/src/midje/repl.clj
@@ -385,8 +385,8 @@
 (defonce ^{:doc "Stores last exception encountered in autotesting"}
   *me nil)
 
-(defn- on-require-failure [the-ns throwable]
-  (println (color/fail "LOAD FAILURE for " the-ns))
+(defn- on-require-failure [throwable]
+  ;(println (color/fail "LOAD FAILURE for " the-ns))
   (println (.getMessage throwable))
   (emit/fail-silently) ; to make sure last line shows a failure.
   (when (config/running-in-repl?)

--- a/test/midje/data/t_nested_facts.clj
+++ b/test/midje/data/t_nested_facts.clj
@@ -5,7 +5,6 @@
             [midje.test-util :refer :all]
             [midje.util.pile :as pile]))
 
-
 (defn faux-fact
   ([] (gensym))
   ([description]

--- a/test/midje/data/t_project_state.clj
+++ b/test/midje/data/t_project_state.clj
@@ -29,27 +29,6 @@
 
 ;;; Working with modification times and dependencies
 
-(fact "The files to load can be used to find a modification time"
-  (against-background (file-modification-time ..file1..) => 222
-    (file-modification-time ..file2..) => 3333)
-
-  (let [empty-tracker {time-key 11
-                       load-key []
-                       filemap-key {..file1.. ..ns1..
-                                    ..file2.. ..ns2..}}
-        tracker-with-changes (assoc empty-tracker load-key [..ns1.. ..ns2..])
-        tracker-with-deleled-ns (assoc empty-tracker load-key [..ns1..]
-                                                     unload-key [..ns1.. ..ns2..]
-                                                     deps-key {:dependents {..ns1.. #{..ns2.. ..ns3..}}})]
-
-    (latest-modification-time empty-tracker) => 11
-    (latest-modification-time tracker-with-changes) => 3333
-
-    (prepare-for-next-scan empty-tracker) => (contains {time-key 11, unload-key [], load-key []})
-    (prepare-for-next-scan tracker-with-changes) => (contains {time-key 3333, unload-key [], load-key []})
-    (prepare-for-next-scan tracker-with-deleled-ns) => (contains {deps-key {:dependents {..ns1.. #{..ns3..}}}})))
-
-
 (def cleaner) ; standin for the calculated dependency cleaner
 (def failure-record (atom {}))
 (defn record-failure [ns throwable]
@@ -57,14 +36,14 @@
 
 
 #_(fact "A namespace list can be loaded, obeying dependents"
-  (require-namespaces! [] record-failure) => anything
+  (#'require-namespaces! [] record-failure) => anything
 
-  (require-namespaces! [..ns1.. ..ns2..] record-failure) => anything
+  (#'require-namespaces! [..ns1.. ..ns2..] record-failure) => anything
   (provided
     (require ..ns1.. :reload) => nil
     (require ..ns2.. :reload) => nil)
 
-  (require-namespaces! [..ns1.. ..ns2..] record-failure) => anything
+  (#'require-namespaces! [..ns1.. ..ns2..] record-failure) => anything
   (provided
     (require ..ns1.. :reload) => nil
     (require ..ns2.. :reload) => nil)
@@ -72,7 +51,7 @@
 
 
   (let [throwable (Error.)]
-    (require-namespaces! [..ns1.. ..ns2.. ..ns3..] record-failure) => anything
+    (#'require-namespaces! [..ns1.. ..ns2.. ..ns3..] record-failure) => anything
     (provided
       (require ..ns1.. :reload) =throws=> throwable
       (require ..ns3.. :reload) => nil)

--- a/test/midje/data/t_project_state.clj
+++ b/test/midje/data/t_project_state.clj
@@ -50,31 +50,21 @@
     (prepare-for-next-scan tracker-with-deleled-ns) => (contains {deps-key {:dependents {..ns1.. #{..ns3..}}}})))
 
 
-(fact "a dependents cleaner knows how to remove namespaces that depend on a namespace"
-  (let [tracker {deps-key {:dependents {..ns1.. [..ns2..]
-                                        ..ns2.. [..ns3..]
-                                        ..ns3.. []}}}
-        cleaner (mkfn:clean-dependents tracker)]
-    (cleaner ..ns1.. [..ns2.. ..ns3..]) => empty?
-    (cleaner ..ns2.. [..ns1.. ..ns3..]) => [..ns1..]
-    (cleaner ..ns3.. [..ns1..]) => [..ns1..]))
-
-
 (def cleaner) ; standin for the calculated dependency cleaner
 (def failure-record (atom {}))
 (defn record-failure [ns throwable]
   (swap! failure-record (constantly {:ns ns, :throwable throwable})))
 
 
-(fact "A namespace list can be loaded, obeying dependents"
-  (require-namespaces! [] record-failure cleaner) => anything
+#_(fact "A namespace list can be loaded, obeying dependents"
+  (require-namespaces! [] record-failure) => anything
 
-  (require-namespaces! [..ns1.. ..ns2..] record-failure cleaner) => anything
+  (require-namespaces! [..ns1.. ..ns2..] record-failure) => anything
   (provided
     (require ..ns1.. :reload) => nil
     (require ..ns2.. :reload) => nil)
 
-  (require-namespaces! [..ns1.. ..ns2..] record-failure cleaner) => anything
+  (require-namespaces! [..ns1.. ..ns2..] record-failure) => anything
   (provided
     (require ..ns1.. :reload) => nil
     (require ..ns2.. :reload) => nil)
@@ -82,10 +72,9 @@
 
 
   (let [throwable (Error.)]
-    (require-namespaces! [..ns1.. ..ns2.. ..ns3..] record-failure cleaner) => anything
+    (require-namespaces! [..ns1.. ..ns2.. ..ns3..] record-failure) => anything
     (provided
       (require ..ns1.. :reload) =throws=> throwable
-      (cleaner ..ns1.. [..ns2.. ..ns3..]) => [..ns3..]
       (require ..ns3.. :reload) => nil)
     @failure-record => {:ns ..ns1.. :throwable throwable}))
 

--- a/test/midje/emission/plugins/t_junit.clj
+++ b/test/midje/emission/plugins/t_junit.clj
@@ -1,11 +1,15 @@
 (ns midje.emission.plugins.t-junit
-  (:require [midje
-             [sweet :refer :all]
-             [util :refer :all]
-             [test-util :refer :all]]
+  (:require [midje.sweet :refer :all]
+            [midje.util :refer :all]
+            [midje.test-util :refer :all]
             [midje.emission.plugins.junit :as plugin]
             [midje.config :as config]
-            [midje.emission.plugins.default-failure-lines :as failure-lines]))
+            [midje.emission.plugins.default-failure-lines :as failure-lines]
+            [midje.util.ecosystem :as ecosystem]))
+
+(def stashed-config (identity config/*config*))
+(println stashed-config)
+(flush)
 
 (defn innocuously [key & args]
   (config/with-augmented-config {:emitter     'midje.emission.plugins.junit
@@ -20,36 +24,37 @@
   :namespace "midje.emission.plugins.t-junit"})
 
 (fact "Entering a new namespace opens a file."
-      (prerequisites
-       (#'plugin/log-fn) => #(println %)
-       (#'plugin/clear-file (contains "test-namespace")) => nil :times 1
-       (#'plugin/clear-file (contains "other-namespace")) => nil :times 1
-       (#'plugin/clear-file (contains "placeholder-to-reset-namespace")) => nil :times 1)
+  (prerequisites
+    (#'plugin/log-fn) => #(println %)
+    (#'plugin/clear-file (contains "test-namespace")) => nil :times 1
+    (#'plugin/clear-file (contains "other-namespace")) => nil :times 1
+    (#'plugin/clear-file (contains "placeholder-to-reset-namespace")) => nil :times 1)
 
-      (innocuously :possible-new-namespace 'test-namespace)
-      => (contains "<testsuite name='test-namespace'")
-      ;; re-entering namespace must not output anything
-      (innocuously :possible-new-namespace 'test-namespace)
-      => ""
-      ;; entering a different namespace must close previous one
-      (innocuously :possible-new-namespace 'other-namespace)
-      ;; FIXME: nicer test for 'both strings present'
-      => (contains (str "</testsuite>" "\n" "<testsuite name='other-namespace'"))
-      (innocuously :possible-new-namespace 'placeholder-to-reset-namespace))
+  (innocuously :possible-new-namespace 'test-namespace)
+  => (contains "<testsuite name='test-namespace'")
+  ;; re-entering namespace must not output anything
+  (innocuously :possible-new-namespace 'test-namespace)
+  => ""
+  ;; entering a different namespace must close previous one
+  (innocuously :possible-new-namespace 'other-namespace)
+  ;; FIXME: nicer test for 'both strings present'
+  => (contains (str "</testsuite>" "\n" "<testsuite name='other-namespace'"))
+  (innocuously :possible-new-namespace 'placeholder-to-reset-namespace))
 
 ;; FIXME: this statefullnes is ugly and hard to test.
 ;; if this fact runs standalone, the :possible-new-namespace will try to clear
 ;; the report file. Otherwise, it was already done in previous test.
 ;; perhaps a plugin/clear-state in a fixture would help.
 (fact "Closing a fact stream closes testsuite"
-      (prerequisites
-       (#'plugin/clear-file (contains "test-namespace")) => nil
-       (#'plugin/clear-file (contains "placeholder-to-reset-namespace")) => nil :times 1
-       (#'plugin/log-fn) => #(println %))
-      (innocuously :possible-new-namespace 'test-namespace)
-      (innocuously :finishing-fact-stream {} {})
-      => (contains "</testsuite>")
-      (innocuously :possible-new-namespace 'placeholder-to-reset-namespace))
+  (prerequisites
+    (#'plugin/clear-file (contains "test-namespace")) => nil
+    (#'plugin/clear-file (contains "placeholder-to-reset-namespace")) => nil :times 1
+    (#'plugin/log-fn) => #(println %))
+
+  (innocuously :possible-new-namespace 'test-namespace)
+  (innocuously :finishing-fact-stream {} {})
+  => (contains "</testsuite>")
+  (innocuously :possible-new-namespace 'placeholder-to-reset-namespace))
 
 (fact "pass produces a <testcase> tag"
   (plugin/starting-to-check-fact test-fact)
@@ -81,3 +86,12 @@
   (innocuously :fail test-failure-map) => (contains "<failure type=':some-prerequisites-were-called-the-wrong-number-of-times'>")
   (provided
     (#'plugin/log-fn) => #(println %)))
+
+;; TODO PLM: fix this horrible hack!
+;; When the junit plugin loads, it manually resets the config. If you are
+;; testing the junit plugin, this means that future tests in other files will
+;; use that new config, which makes test output super verbose. The way forward,
+;; as far as I can tell, is to somehow provide an unloading mechanism for midje
+;; plugins, not unlike 'components'
+(config/change-defaults :print-level :print-namespaces
+                        :colorize (not (ecosystem/on-windows?)))

--- a/test/midje/emission/t_colorize.clj
+++ b/test/midje/emission/t_colorize.clj
@@ -51,7 +51,6 @@
 ;; Reset to user's default colorization.
 (color/init!)
 
-
 (fact "access environment vars only when namespace is loaded, not on each report line"
   (prerequisite (getenv "MIDJE_COLORIZE") => anything :times 0)
 

--- a/test/user/fus_check_after_creation.clj
+++ b/test/user/fus_check_after_creation.clj
@@ -8,8 +8,7 @@
 (config/with-augmented-config {:check-after-creation false}
   (fact "fact" 1 => "fact")
   (facts "facts" 1 => "facts")
-  (future-fact (throw (new Error ":check-after-creation fail")))
-)
+  (future-fact (throw (new Error ":check-after-creation fail"))))
 
 (silent-check-facts *ns* #"^fact$")
 (note-that fact-failed (fact-expected "fact"))
@@ -38,4 +37,3 @@
     (fact 1 => :never-executed)))
 
 (note-that (fact-failed-with-note #"It is meaningless to combine.*with-state-changes.*:check-after-creation"))
-


### PR DESCRIPTION
__WIP__: There are still some issues to iron out and a lot of functionality to check still works.

Was trying to use clojure protocols in some Midje code and was running up against bugs where files with `defprotocol`s got reloaded, creating new protocols, and borking old instances ([as mentioned here](https://github.com/clojure/tools.namespace#reloading-code-motivation)). 
The way forward is use the [`tools.namespace`](https://github.com/clojure/tools.namespace) lib in a more high-level manner.

This will also fix https://github.com/marick/Midje/issues/288

This code is heavily influenced by https://github.com/jakemcc/lein-test-refresh, so many thanks to the maintainers of that lib

Potential issues: 
 - code changes in the `midje.emission.plugins.default` emission plugin are not reloaded during `autotest`