### PR TITLE
Avoid code generation in counters code

### DIFF
--- a/src/midje/emission/clojure_test_facade.clj
+++ b/src/midje/emission/clojure_test_facade.clj
@@ -16,7 +16,6 @@
 (defn note-fail [] (ct/inc-report-counter :fail))
 (defn note-test [] (ct/inc-report-counter :test))
 
-
 (defn run-tests
   "Run clojure.test tests in the given namespaces. It does not
    affect the Midje fact counters but instead returns a map

--- a/src/midje/emission/state.clj
+++ b/src/midje/emission/state.clj
@@ -1,10 +1,7 @@
-(ns ^{:doc
-"This namespace contains [will eventually contain] all the
- non-configuration state of the program. That is: the workings
- that are normally invisible to any user, with the exception
- of tests and people debugging."}
-  midje.emission.state
-  (:require [midje.util.ecosystem :as ecosystem]))
+(ns ^{:doc "The non-configuration state of the program. That is: the workings
+           that are normally invisible to any user, with the exception of tests
+           and people debugging."}
+  midje.emission.state)
 
 ;;; At some point, figure out how to do nested splicing quotes.
 (defn make-defmacro-body [ns name reset-name set-name body]
@@ -14,7 +11,6 @@
        ~@body
      (finally
        ((ns-resolve '~ns '~set-name) original-value#)))))
-
 
 (defmacro make-counter-atom [name & keys]
   (let [atom-name (symbol (str name "-atom"))
@@ -49,11 +45,8 @@
          ~@(map make-one-setter keys)
          ~@(map make-one-incrementer keys)))))
 
-
-
 (make-counter-atom output-counters
   :midje-passes :midje-failures)
-
 
 (def raw-fact-failures-atom (atom :uninitialized))
 (def raw-fact-failures #(deref raw-fact-failures-atom))
@@ -77,4 +70,3 @@
 (defmacro with-emission-map [map & body]
   `(binding [emission-functions ~map]
      ~@body))
-

--- a/src/midje/emission/state.clj
+++ b/src/midje/emission/state.clj
@@ -3,14 +3,6 @@
            and people debugging."}
   midje.emission.state)
 
-(defmacro with-isolated-output-counters [& body]
-  `(let [original-value# (output-counters)]
-     (try
-       (reset-output-counters!)
-       ~@body
-     (finally
-       (set-output-counters! original-value#)))))
-
 (def ^:dynamic output-counters-atom (atom :undefined))
 (defn output-counters []
   (deref output-counters-atom))
@@ -42,6 +34,14 @@
 
 (defn output-counters:inc:midje-failures! []
   (swap!  output-counters-atom (partial merge-with +) {:midje-failures 1}))
+
+(defmacro with-isolated-output-counters [& body]
+  `(let [original-value# (output-counters)]
+     (try
+       (reset-output-counters!)
+       ~@body
+     (finally
+       (set-output-counters! original-value#)))))
 
 (def raw-fact-failures-atom (atom :uninitialized))
 (def raw-fact-failures #(deref raw-fact-failures-atom))


### PR DESCRIPTION
Expand by hand a macro that was only called once at the top-level of a namespace.

This is helpful for future development because the macro defines various functions dynamically, so if you are trying to find the definition of `output-counters:midje-failures`, `output-counters:inc:midje-passes!`, etc, you can now grep the code instead of having to understand the fairly-complex macro