### PR TITLE
Change clojure.test output order

### DIFF
--- a/src/midje/emission/plugins/default.clj
+++ b/src/midje/emission/plugins/default.clj
@@ -35,43 +35,45 @@
                                                   (fact/line fact)])))))))
 
 
+(defn- midje-summary-lines [passes fails]
+  (letfn [(midje-failure-summary []
+            (if (= 1 fails)
+              (str (color/fail "FAILURE:") (format " %d check failed." fails))
+              (str (color/fail "FAILURE:") (format " %d checks failed." fails))))
+
+          (midje-consolation []
+            (condp = passes
+              0 ""
+              (format " (But %d succeeded.)" passes)))]
+
+    (vector
+      (cond (zero? (+ passes fails))
+            (color/note "No facts were checked. Is that what you wanted?")
+
+            (zero? fails)
+            (color/pass (format "All checks (%d) succeeded." passes))
+
+            :else
+            (str (midje-failure-summary) " " (midje-consolation))))))
+
+(defn- clojure-test-prompted-lines [clojure-test-map]
+  (when (pos? (:test clojure-test-map))
+    (let [lines (:lines clojure-test-map)
+          result-lines (drop-last 2 lines)
+          summary-line (last lines)
+          grievousness? (pos? (+ (:fail clojure-test-map) (:error clojure-test-map)))]
+      (concat [(color/note ">>> Output from clojure.test tests:")]
+              (map #(-> % (str/replace #"^FAIL" (color/fail "FAIL"))
+                        (str/replace #"^ERROR" (color/fail "ERROR")))
+                   result-lines)
+              [((if grievousness? color/fail color/pass) summary-line)]
+              [(color/note ">>> Midje summary:")]))))
+
 (defn finishing-fact-stream [midje-counters clojure-test-map]
-  (letfn [(midje-summary-lines [passes fails]
-            (letfn [(midje-failure-summary []
-                      (if (= 1 fails)
-                        (str (color/fail "FAILURE:") (format " %d check failed." fails))
-                        (str (color/fail "FAILURE:") (format " %d checks failed." fails))))
-
-                    (midje-consolation []
-                      (condp = passes
-                        0 ""
-                        (format " (But %d succeeded.)" passes)))]
-
-              (vector
-               (cond (zero? (+ passes fails))
-                     (color/note "No facts were checked. Is that what you wanted?")
-
-                     (zero? fails)
-                     (color/pass (format "All checks (%d) succeeded." passes))
-
-                     :else
-                     (str (midje-failure-summary) " " (midje-consolation))))))
-
-          (clojure-test-prompted-lines []
-            (when (pos? (:test clojure-test-map))
-              (let [lines (:lines clojure-test-map)
-                    result-lines (drop-last 2 lines)
-                    summary-line (last lines)
-                    grievousness? (pos? (+ (:fail clojure-test-map) (:error clojure-test-map)))]
-                (concat [(color/note ">>> Output from clojure.test tests:")]
-                        (map #(-> % (str/replace #"^FAIL" (color/fail "FAIL"))
-                                  (str/replace #"^ERROR" (color/fail "ERROR")))
-                             result-lines)
-                        [((if grievousness? color/fail color/pass) summary-line)]
-                        [(color/note ">>> Midje summary:")]))))]
-
-    (apply util/emit-one-line (concat (clojure-test-prompted-lines)
-                                      (midje-summary-lines (:midje-passes midje-counters) (:midje-failures midje-counters))))))
+  (apply util/emit-one-line
+         (concat (clojure-test-prompted-lines clojure-test-map)
+                 (midje-summary-lines (:midje-passes midje-counters)
+                                      (:midje-failures midje-counters)))))
 
 (defn future-fact [description-list position]
   (util/emit-one-line "")

--- a/test/midje/emission/plugins/t_default.clj
+++ b/test/midje/emission/plugins/t_default.clj
@@ -64,16 +64,13 @@
                                    :error 1
                                    :lines ["line 1"
                                            "line 2"
-                                           ""
-                                           "summary line"]}))
-    => (contains #"Output from clojure.test"
+                                           "successes"
+                                           "failures"]}))
+    => (contains #"Midje summary"
+                 #"All checks \(2\) succeeded."
+                 #""
+                 #"Output from clojure.test"
                  #"line 1"
                  #"line 2"
-                 #"summary line"
-                 #"Midje summary"
-                 #"All checks \(2\) succeeded.")
-    ))
-
-
-
-
+                 #"successes"
+                 #"failures")))


### PR DESCRIPTION
Midje has the ability to check `clojure.test` tests, and when it does, will include them in the test summary.
The ordering of this summary is a bit unclear, because first midje checks normal midje facts, printing namespaces loaded (if configured to do so), then it outputs results from `clojure.test` tests, then it finally prints results of the midje facts.

The changes I'm proposing here will show the midje results first so they will appear with the fact namespaces loaded, and then show the `clojure.test` results.

I've also adapted the `clojure.test` results to show how many tests were run, which is currently not shown.

Before:
```
$ lein midje :autotest
...
= Namespace midje.emission.t-deprecation
= Namespace as-documentation.about-defrecord.using-refer--plain-tests.test
= Namespace midje.emission.plugins.t-default-failure-lines
>>> Output from clojure.test tests:
= Namespace behaviors.background-nesting.t-left-to-right
= Namespace behaviors.background-nesting.t-three-levels-outside
= Namespace implementation.line-numbers.fim-check-failures
= Namespace behaviors.background-nesting.t-three-levels
= Namespace behaviors.background-nesting.t-shadowing
= Namespace behaviors.background_nesting.t-background-command
= Namespace behaviors.background-nesting.t-outside
= Namespace behaviors.folded-prerequisites-and-namespaces.t-using-namespace
= Namespace behaviors.background-nesting.t-shadowing-outside-background

0 failures, 0 errors.
>>> Midje summary:
All checks (373) succeeded.
[Completed at 12:06:25]
```

After:
```
$ lein midje :autotest
...
= Namespace midje.emission.t-deprecation
= Namespace as-documentation.about-defrecord.using-refer--plain-tests.test
= Namespace midje.emission.plugins.t-default-failure-lines
>>> Midje summary:
All checks (373) succeeded.

>>> Output from clojure.test tests:
= Namespace behaviors.background-nesting.t-left-to-right
= Namespace behaviors.background-nesting.t-three-levels-outside
= Namespace implementation.line-numbers.fim-check-failures
= Namespace behaviors.background-nesting.t-three-levels
= Namespace behaviors.background-nesting.t-shadowing
= Namespace behaviors.background_nesting.t-background-command
= Namespace behaviors.background-nesting.t-outside
= Namespace behaviors.folded-prerequisites-and-namespaces.t-using-namespace
= Namespace behaviors.background-nesting.t-shadowing-outside-background

Ran 34 tests containing 32 assertions.
0 failures, 0 errors.
[Completed at 12:06:25]
```