### PR TITLE
Minor bootstrap refactor

### DIFF
--- a/src/midje/Bootstrap.clj
+++ b/src/midje/Bootstrap.clj
@@ -1,10 +1,14 @@
-(ns midje.Bootstrap)
+(ns midje.Bootstrap
+  (:require [midje.config :as config]
+            [midje.emission.api :as emission.api]
+            [midje.emission.colorize :as emission.colorize]
+            [midje.emission.state :as emission.state]))
 
 (defonce bootstrapped false)
 
 (defn bootstrap []
   (when-not bootstrapped
-    (require 'midje.config)
+
     (let [saved-ns (ns-name *ns*)]
       (try
         (in-ns 'midje.config)
@@ -12,12 +16,8 @@
       (finally
         (in-ns saved-ns))))
 
-    (require 'midje.emission.api)
-    ( (ns-resolve 'midje.emission.api 'load-plugin)
-      ( (ns-resolve 'midje.config 'choice) :emitter))
+    (emission.api/load-plugin (config/choice :emitter))
+    (emission.colorize/init!)
+    (emission.state/no-more-plugin-installation)
 
-    ((ns-resolve 'midje.emission.colorize 'init!))
-
-    ((ns-resolve 'midje.emission.state 'no-more-plugin-installation))
     (alter-var-root #'bootstrapped (constantly true))))
-

--- a/src/midje/bootstrap.clj
+++ b/src/midje/bootstrap.clj
@@ -1,4 +1,4 @@
-(ns midje.Bootstrap
+(ns midje.bootstrap
   (:require [midje.config :as config]
             [midje.emission.api :as emission.api]
             [midje.emission.colorize :as emission.colorize]

--- a/src/midje/sweet.clj
+++ b/src/midje/sweet.clj
@@ -1,5 +1,5 @@
-(require 'midje.Bootstrap)
-(midje.Bootstrap/bootstrap)
+(require 'midje.bootstrap)
+(midje.bootstrap/bootstrap)
 
 (ns ^{:doc "A TDD library for Clojure that supports top-down ('mockish') TDD,
             encourages readable tests, provides a smooth migration path from


### PR DESCRIPTION
Replace usage of `(ns-resolve 'some-namespace 'some-function)` with standard function calls.

I'm concerned that there was a particular reason for the use of `ns-resolve` in these cases, but it doesn't seem to have broken anything and I can't see why it would be used, so I'm proposing removing it to make the code more standard/readable.

Also, lowercase name of `Bootstrap.clj`