### PR TITLE
Allow checkers to be records that implement IFn

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject midje "1.9.0-alpha12"
+(defproject midje "1.9.0-alpha13"
   :description "A TDD library for Clojure that supports top-down ('mockish') TDD, encourages readable tests, provides a smooth migration path from clojure.test, balances abstraction and concreteness, and strives for graciousness."
   :url "https://github.com/marick/Midje"
   :pedantic? :warn
@@ -44,4 +44,4 @@
 
   ;; For Clojure snapshots
   :repositories {"sonatype-oss-public" "https://oss.sonatype.org/content/groups/public/"
-                 "stuartsierra-releases" "http://stuartsierra.com/maven2"})
+                 "stuartsierra-releases" "https://stuartsierra.com/maven2"})

--- a/src/midje/checking/checkers/collection_util.clj
+++ b/src/midje/checking/checkers/collection_util.clj
@@ -1,5 +1,6 @@
 (ns midje.checking.checkers.collection-util
   (:require [commons.clojure.core :refer :all :exclude [any?]]
+            [midje.checking.checkers.defining :as defining]
             [midje.checking.core :refer :all]))
 
 (defn same-lengths? [actual expected]
@@ -10,6 +11,7 @@
    in a seq? (Ex: regex #'a+' can match 'a' and 'aa'.)"
   [checker]
   (or (extended-fn? checker)
+      (defining/checker? checker)
       (regex? checker)))
 
 (defn total-match?

--- a/src/midje/checking/core.clj
+++ b/src/midje/checking/core.clj
@@ -3,6 +3,7 @@
   (:require [commons.clojure.core :refer :all :exclude [any?]]
             ;; TODO: Shouldn't really have this dependency.
             [midje.emission.plugins.util :as names]
+            [midje.checking.checkers.defining :as defining]
             [such.sequences :as seq]))
 
 ;;; There is a notion of "extended falsehood", in which a false value may be a
@@ -61,7 +62,8 @@
     (cond
       (data-laden-falsehood? actual)           [actual {}]
       (data-laden-falsehood? expected)         [expected {}]
-      (extended-fn? expected)                  (evaluate-checking-function expected actual)
+      (or (extended-fn? expected)
+          (defining/checker? expected))        (evaluate-checking-function expected actual)
       (every? regex? [actual expected])        [(= (str actual) (str expected)) {}]
       (regex? expected)                        [(re-find expected actual) {}]
       (and (record? actual)


### PR DESCRIPTION
If you have a record that implements `IFn` and is marked as a midje checker, then treat it like one, instead of trying to cast it to a map during checking.

Needed for https://github.com/rafaeldff/matcher-combinators/pull/1

TODO: write tests