### PR TITLE
1.9.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,43 @@
 This project adheres to [Semantic Versioning](http://semver.org/).
 See [here](http://keepachangelog.com/) for the change log format.
 
+## [1.9.0] - 2017-11-21
+
+### Changed
+- [POTENTIALLY BREAKING] Fail when `=contains=>` targets a non-map value, such as a vector, which has unclear semantics. A fact that looks like
+
+```clojure
+(unfinished gen-list)
+(fact
+  (first (gen-list)) => 'list
+  (provided
+    (gen-list) => ..some-list..
+    ..some-list.. =contains=> ['list 'contains 'not-suppored]`))
+```
+
+can be updated to
+
+```clojure
+(let [some-list ['list 'contains 'not-suppored]
+  (fact
+    (first (gen-list)) => 'list
+    (provided
+      (gen-list) => some-list)))
+```
+
+Note that clojure doesn't allow var names that begin with `.` (like `..some-metaconstant..`) in `let`-forms
+
+### Added
+- Experimental [`for-all`](https://github.com/marick/Midje/wiki/Generative-testing-with-for-all) construct for quick-check style testing, powered by `clojure.test.check`. Currently in the `midje.experimental` namespace.
+- Pretty printing output and exceptions. Can be disabled by setting the `:pretty-print` configuration to `false`.
+- Support for the using the same metaconstant in a function fake and `=contains=>` ([#159](https://github.com/marick/Midje/issues/159))
+
+### Removed
+- Drop support for Clojure `1.5` and `1.6`
+
+### Fixed
+See fixes noted in versions since `1.8.3`
+
 ## [1.9.0-alpha12] - 2017-11-14
 - allow `for-all` to appear inside of `fact` forms
 

--- a/README.md
+++ b/README.md
@@ -1,15 +1,9 @@
 Available via [clojars](https://clojars.org/midje)
 
-Stable version: 
+Stable version:
 
 ```clojure
-[midje "1.8.3"]
-```
-
-Experimental version: 
-
-```clojure
-[midje "1.9.0-alpha12"]
+[midje "1.9.0"]
 ```
 
 License: [MIT](http://en.wikipedia.org/wiki/MIT_License)

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject midje "1.9.0-alpha12"
+(defproject midje "1.9.0"
   :description "A TDD library for Clojure that supports top-down ('mockish') TDD, encourages readable tests, provides a smooth migration path from clojure.test, balances abstraction and concreteness, and strives for graciousness."
   :url "https://github.com/marick/Midje"
   :pedantic? :warn
@@ -25,7 +25,7 @@
              :test-libs {:dependencies [[prismatic/plumbing "0.5.4"]]}
              :1.7 [:test-libs {:dependencies [[org.clojure/clojure "1.7.0"]]}]
              :1.8 [:test-libs {:dependencies [[org.clojure/clojure "1.8.0"]]}]
-             :1.9 [:test-libs {:dependencies [[org.clojure/clojure "1.9.0-alpha17"]]}]
+             :1.9 [:test-libs {:dependencies [[org.clojure/clojure "1.9.0-RC1"]]}]
              ;; The following profile can be used to check that `lein with-profile`
              ;; profiles are obeyed. Note that profile `:test-paths` *add on* to the
              ;; defaults.

--- a/src/midje/experimental.clj
+++ b/src/midje/experimental.clj
@@ -1,0 +1,21 @@
+(ns midje.experimental
+  (:require [midje.parsing.0-to-fact-form.generative :as parse-generative]
+            [pointer.core :as pointer]))
+
+(defmacro for-all
+  "Check facts using values generated using test.check
+
+  Options
+  :seed       used to re-run previous checks
+  :max-size   controls the size of generated vlues
+  :num-tests  how many times to run the checks
+
+  (for-all 'name \"doc string\"
+    [pos-int gen/s-pos-int]
+    {:num-tests 10}
+    (fact pos-int => integer?))"
+  {:arglists '([binding-form & facts]
+               [name doc-string binding-form opts-map & facts])}
+  [& _]
+  (pointer/set-fallback-line-number-from &form)
+  (parse-generative/parse-for-all &form))

--- a/src/midje/sweet.clj
+++ b/src/midje/sweet.clj
@@ -27,7 +27,6 @@
             [midje.parsing.util.wrapping :as wrapping]
             [pointer.core :as pointer]
             [midje.parsing.0-to-fact-form.tabular :as parse-tabular]
-            [midje.parsing.0-to-fact-form.generative :as parse-generative]
             [midje.parsing.0-to-fact-form.formulas :as parse-formulas]
             [midje.parsing.1-to-explicit-form.facts :as parse-facts]
             [midje.parsing.1-to-explicit-form.parse-background :as parse-background]
@@ -220,25 +219,6 @@
   [& _]
   (pointer/set-fallback-line-number-from &form)
   (parse-tabular/parse (keys &env) &form))
-
-(defmacro for-all
-  "Check facts using values generated using test.check
-
-  Options
-  :seed       used to re-run previous checks
-  :max-size   controls the size of generated vlues
-  :num-tests  how many times to run the checks
-
-  (for-all 'name \"doc string\"
-    [pos-int gen/s-pos-int]
-    {:num-tests 10}
-    (fact pos-int => integer?))"
-  {:arglists '([binding-form & facts]
-               [name doc-string binding-form opts-map & facts])}
-  [& _]
-  (pointer/set-fallback-line-number-from &form)
-  (parse-generative/parse-for-all &form))
-
 
 (defmacro metaconstants
   "For a few operations, such as printing and equality checking,

--- a/test/behaviors/t_for_all.clj
+++ b/test/behaviors/t_for_all.clj
@@ -3,6 +3,7 @@
             [midje.emission.state :as state]
             [midje.repl :as repl]
             [midje.sweet :refer :all]
+            [midje.experimental :refer [for-all]]
             [midje.test-util :refer :all]
             [clojure.test.check.generators :as gen]))
 
@@ -11,7 +12,7 @@
    any-integer  gen/int]
   {:seed 1510160943861}
   (fact (+ strictly-pos any-integer) => pos?))
-(note-that fact-fails (failure-was-at-line 13))
+(note-that fact-fails (failure-was-at-line 14))
 
 (silent-for-all
   [strictly-pos gen/s-pos-int
@@ -19,7 +20,7 @@
   {:seed 1510160943861}
   (fact 1 => 1)
   (+ strictly-pos any-integer) => pos?)
-(note-that fact-fails (failure-was-at-line 21))
+(note-that fact-fails (failure-was-at-line 22))
 
 (silent-for-all "generative tests"
   [strictly-pos gen/s-pos-int

--- a/test/midje/test_util.clj
+++ b/test/midje/test_util.clj
@@ -46,7 +46,7 @@
 (defmacro silent-formula [& _]
   (silent-body 'midje.sweet/formula &form))
 (defmacro silent-for-all [& _]
-  (silent-body 'midje.sweet/for-all &form))
+  (silent-body 'midje.experimental/for-all &form))
 (defmacro silent-against-background [& _]
   (silent-body 'midje.sweet/against-background &form))
 (defmacro silent-with-state-changes [& _]


### PR DESCRIPTION
move `for-all` to experimental namespace in case things need to change after people give it a try