### PR TITLE
add lein-ancient to more easily find out-of-date libs

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -21,7 +21,9 @@
                  [slingshot "0.12.2"]
                  [mvxcvi/puget "1.0.2" :exclusions [org.clojure/clojure]]]
   :profiles {:dev {:dependencies [[prismatic/plumbing "0.5.5"]]
-                   :plugins [[lein-midje "3.2.1"]]}
+                   :plugins [[lein-midje "3.2.1"]
+                             [lein-ancient "0.6.14" :exclusions [com.fasterxml.jackson.core/jackson-databind
+                                                                 com.fasterxml.jackson.core/jackson-core]]]}
              :test-libs {:dependencies [[prismatic/plumbing "0.5.5"]]}
              :1.7 [:test-libs {:dependencies [[org.clojure/clojure "1.7.0"]]}]
              :1.8 [:test-libs {:dependencies [[org.clojure/clojure "1.8.0"]]}]

--- a/project.clj
+++ b/project.clj
@@ -46,4 +46,4 @@
 
   ;; For Clojure snapshots
   :repositories {"sonatype-oss-public" "https://oss.sonatype.org/content/groups/public/"
-                 "stuartsierra-releases" "http://stuartsierra.com/maven2"})
+                 "stuartsierra-releases" "https://stuartsierra.com/maven2"})


### PR DESCRIPTION
with this change, running `lein ancient` will show all libs that have newer versions available.