### PR TITLE
Pin specter lib version and bump to clojure 1.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 This project adheres to [Semantic Versioning](http://semver.org/).
 See [here](http://keepachangelog.com/) for the change log format.
 
+## [1.9.1] - 2017-12-19
+
+- pin specter version to fix import warning in suchwow
+- use released version of clojure 1.9
+
 ## [1.9.0] - 2017-11-21
 
 ### Changed

--- a/project.clj
+++ b/project.clj
@@ -1,9 +1,11 @@
-(defproject midje "1.9.0"
+(defproject midje "1.9.1"
   :description "A TDD library for Clojure that supports top-down ('mockish') TDD, encourages readable tests, provides a smooth migration path from clojure.test, balances abstraction and concreteness, and strives for graciousness."
   :url "https://github.com/marick/Midje"
   :pedantic? :warn
-  :dependencies [[org.clojure/clojure "1.8.0"]
+  :dependencies [[org.clojure/clojure "1.9.0"]
                  [marick/suchwow "6.0.0" :exclusions [org.clojure/clojure org.clojure/clojurescript]]
+                 ;; for now pin specter version to override old version in suchwow. Remove once suchwow is updated
+                 [com.rpl/specter "1.0.4" :exclusions [org.clojure/clojure org.clojure/clojurescript]]
                  [marick/clojure-commons "3.0.0" :exclusions [org.clojure/clojure]]
                  ;; structural-typing currently broken with specter 0.13
                  ;; [marick/structural-typing "2.0.4" :exclusions [org.clojure/clojure org.clojure/clojurescript]]
@@ -25,7 +27,7 @@
              :test-libs {:dependencies [[prismatic/plumbing "0.5.5"]]}
              :1.7 [:test-libs {:dependencies [[org.clojure/clojure "1.7.0"]]}]
              :1.8 [:test-libs {:dependencies [[org.clojure/clojure "1.8.0"]]}]
-             :1.9 [:test-libs {:dependencies [[org.clojure/clojure "1.9.0-RC2"]]}]
+             :1.9 [:test-libs {:dependencies [[org.clojure/clojure "1.9.0"]]}]
              ;; The following profile can be used to check that `lein with-profile`
              ;; profiles are obeyed. Note that profile `:test-paths` *add on* to the
              ;; defaults.

--- a/project.clj
+++ b/project.clj
@@ -46,4 +46,4 @@
 
   ;; For Clojure snapshots
   :repositories {"sonatype-oss-public" "https://oss.sonatype.org/content/groups/public/"
-                 "stuartsierra-releases" "http://stuartsierra.com/maven2"})
+                 "stuartsierra-releases" "https://stuartsierra.com/maven2"})

--- a/src/midje/checking/checkers/chatty.clj
+++ b/src/midje/checking/checkers/chatty.clj
@@ -2,7 +2,6 @@
   midje.checking.checkers.chatty
   (:require [commons.clojure.core :refer :all :exclude [any?]]
             [midje.checking.checkers.defining :refer [as-checker]]
-            [midje.checking.checkers.util :refer [named-as-call]]
             [midje.checking.core :refer :all]
             [midje.emission.colorize :as colorize]
             [midje.parsing.util.core :refer [quoted?]]


### PR DESCRIPTION
Resolves https://github.com/marick/Midje/issues/427 by pinning the `specter` version.
Will undo the pinned specter version and bump suchwow when the changes in https://github.com/marick/suchwow/pull/9 get published to clojars.

also bump to use clojure 1.9 as the default version.