### PR TITLE
Show record class in conventional way when printing records

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,10 @@
 This project adheres to [Semantic Versioning](http://semver.org/).
 See [here](http://keepachangelog.com/) for the change log format.
 
-## [1.9.2-SNAPSHOT] - 2017-12-26
+## [1.9.2] - 2017-12-27
 
 - Print records in conventional way `#user.YourRecord {:arg-one 100}`, instead of `{:arg-one 100}::YourRecord`
+- Fix upstream reflection warnings in `suchwow`
 
 ## [1.9.1] - 2017-12-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 This project adheres to [Semantic Versioning](http://semver.org/).
 See [here](http://keepachangelog.com/) for the change log format.
 
+## [1.9.2-SNAPSHOT] - 2017-12-26
+
+- Print records in conventional way `#user.YourRecord {:arg-one 100}`, instead of `{:arg-one 100}::YourRecord`
+
 ## [1.9.1] - 2017-12-19
 
 - pin specter version to fix import warning in suchwow

--- a/project.clj
+++ b/project.clj
@@ -1,11 +1,9 @@
-(defproject midje "1.9.2-SNAPSHOT"
+(defproject midje "1.9.2"
   :description "A TDD library for Clojure that supports top-down ('mockish') TDD, encourages readable tests, provides a smooth migration path from clojure.test, balances abstraction and concreteness, and strives for graciousness."
   :url "https://github.com/marick/Midje"
   :pedantic? :warn
   :dependencies [[org.clojure/clojure "1.9.0"]
-                 [marick/suchwow "6.0.0" :exclusions [org.clojure/clojure org.clojure/clojurescript]]
-                 ;; for now pin specter version to override old version in suchwow. Remove once suchwow is updated
-                 [com.rpl/specter "1.0.4" :exclusions [org.clojure/clojure org.clojure/clojurescript]]
+                 [marick/suchwow "6.0.1" :exclusions [org.clojure/clojure org.clojure/clojurescript]]
                  [marick/clojure-commons "3.0.0" :exclusions [org.clojure/clojure]]
                  ;; structural-typing currently broken with specter 0.13
                  ;; [marick/structural-typing "2.0.4" :exclusions [org.clojure/clojure org.clojure/clojurescript]]

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject midje "1.9.1"
+(defproject midje "1.9.2-SNAPSHOT"
   :description "A TDD library for Clojure that supports top-down ('mockish') TDD, encourages readable tests, provides a smooth migration path from clojure.test, balances abstraction and concreteness, and strives for graciousness."
   :url "https://github.com/marick/Midje"
   :pedantic? :warn

--- a/src/midje/emission/plugins/util.clj
+++ b/src/midje/emission/plugins/util.clj
@@ -111,15 +111,6 @@
        (take-last 2)
        (str/join "/")))
 
-(defn record-name [value]
-  (.getName (class value)))
-
-(defn record-name-shorthand [value]
-  (last (str/split (record-name value) #"\.")))
-
-(defn maplike-name [value]
-  (if (classic-map? value) "map" (record-name-shorthand value)))
-
 (defn prerequisite-var-description
   "Takes a var naming a prerequisite and returns a string useful for printing"
   [prerequisite-var]
@@ -144,8 +135,8 @@
   (if (exception/captured-throwable? v)
     (exception/friendly-stacktrace v)
     (let [raw-str (cond (fn? v)     (function-name v)
-                        (record? v) (str (sorted-if-appropriate v) "::" (record-name v))
-                        :else       (sorted-if-appropriate v))]
+                        (record? v) v
+                        :else       (nested-sort v))]
       (cond
         (config/choice :pretty-print)
         (puget/cprint-str raw-str {:print-handlers {Metaconstant puget/pr-handler}

--- a/test/implementation/fim_open_protocols.clj
+++ b/test/implementation/fim_open_protocols.clj
@@ -36,4 +36,9 @@
 
 
 
+(defprotocol Caller
+  (call [caller x]))
+
+(defn fake-func [arg] 'shouldnt-return)
+
 

--- a/test/implementation/fim_open_protocols.clj
+++ b/test/implementation/fim_open_protocols.clj
@@ -36,9 +36,4 @@
 
 
 
-(defprotocol Caller
-  (call [caller x]))
-
-(defn fake-func [arg] 'shouldnt-return)
-
 


### PR DESCRIPTION
For (nested) records like
```clojure
(->Outer (->Inner 1))
```
Midje used to print the expected output as
```clojure
{:outer-value {:inner-value 1}}::implementation.fim_open_protocols.Outer
```
which meant that you didn't know that the inner map was in fact a record. In addition, the `::ClassName` notation isn't standard to Clojure

This PR changes the record printing to the following, which makes it clear that there are nested records, and also uses the dispatch macro convention (`#ClassName {...}`):
```clojure
#implementation.fim_open_protocols.Outer {:outer-value #implementation.fim_open_protocols.Inner {:inner-value 1}}
```

Some background in https://github.com/marick/Midje/issues/401#issuecomment-353996422