### PR TITLE
Disallow faking of `clojure.core` functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 This project adheres to [Semantic Versioning](http://semver.org/).
 See [here](http://keepachangelog.com/) for the change log format.
 
-## [1.9.2-alpha3] - 2018-01-03
-- Disallow faking of all functions in `clojure.core`. If Midje happens to use any of them in code paths executed while they are redifined, it will change the behavior of Midje.
+## [2.0.0-alpha1] - 2018-01-12
+- __BREAKING__ Disallow faking of all functions in `clojure.core`. This is a safety measure because if Midje happens to use any of them in code paths executed while they are redefined, it will change the behavior of Midje. Any tests that previously faked `clojure.core` functions will need to be adapted by either wrapping them in a custom function that can be safely faked, or tweaking the test to not require faking.
 
 ## [1.9.2-alpha2] - 2018-01-03
 - 431: __POTENTIALLY BREAKING__ Fix issue where you can fake functions with incorrect arities. Function faking now produces a test failure if you provide more or less arguments than expected by the function definition. This may break tests that incorrectly faked functions, but this is a good thing because it will reveal bugs in your tests.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 This project adheres to [Semantic Versioning](http://semver.org/).
 See [here](http://keepachangelog.com/) for the change log format.
 
+## [1.9.2-alpha3] - 2018-01-03
+- Disallow faking of all functions in `clojure.core`. If Midje happens to use any of them in code paths executed while they are redifined, it will change the behavior of Midje.
+
 ## [1.9.2-alpha2] - 2018-01-03
 - 431: __POTENTIALLY BREAKING__ Fix issue where you can fake functions with incorrect arities. Function faking now produces a test failure if you provide more or less arguments than expected by the function definition. This may break tests that incorrectly faked functions, but this is a good thing because it will reveal bugs in your tests.
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject midje "1.9.2-alpha3"
+(defproject midje "2.0.0-alpha1"
   :description "A TDD library for Clojure that supports top-down ('mockish') TDD, encourages readable tests, provides a smooth migration path from clojure.test, balances abstraction and concreteness, and strives for graciousness."
   :url "https://github.com/marick/Midje"
   :pedantic? :warn

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject midje "1.9.2-alpha2"
+(defproject midje "1.9.2-alpha3"
   :description "A TDD library for Clojure that supports top-down ('mockish') TDD, encourages readable tests, provides a smooth migration path from clojure.test, balances abstraction and concreteness, and strives for graciousness."
   :url "https://github.com/marick/Midje"
   :pedantic? :warn

--- a/src/midje/checking/checkers/chatty.clj
+++ b/src/midje/checking/checkers/chatty.clj
@@ -35,8 +35,11 @@
       [[] []]
       arglist))
 
+(defn- gen-destruct-symbol []
+  (gensym 'symbol-for-destructured-arg))
+
 (defn- ^{:testable true} single-destructuring-arg->form+name [arg-form]
-  (let [as-symbol          (gensym 'symbol-for-destructured-arg)
+  (let [as-symbol          (gen-destruct-symbol)
         snd-to-last-is-as? #(= :as (second (reverse %)))
         has-key-as?        #(contains? % :as)]
     (branch-on arg-form

--- a/src/midje/parsing/2_to_lexical_maps/fakes.clj
+++ b/src/midje/parsing/2_to_lexical_maps/fakes.clj
@@ -13,8 +13,15 @@
 (defn- compiler-will-inline-fn? [var]
   (contains? (meta var) :inline))
 
-(defn- is-core? [var]
-  (-> var meta :ns ns-name (= 'clojure.core)))
+(defn- is-core?
+  "Is a variable from `clojure.core`, excluding `rand`.
+
+   `rand` is excluded because it is useful to fake and unused by Midje, so
+   there is no danger to faking it"
+  [var]
+  (let [var-meta (meta var)]
+    (and (not (= 'rand (:name var-meta)))
+         (= 'clojure.core (some-> var-meta :ns ns-name)))))
 
 (defn- exposed-testable? [var]
   (contains? (meta var) :testable))

--- a/src/midje/parsing/2_to_lexical_maps/fakes.clj
+++ b/src/midje/parsing/2_to_lexical_maps/fakes.clj
@@ -13,17 +13,11 @@
 (defn- compiler-will-inline-fn? [var]
   (contains? (meta var) :inline))
 
+(defn- is-core? [var]
+  (-> var meta :ns ns-name (= 'clojure.core)))
+
 (defn- exposed-testable? [var]
   (contains? (meta var) :testable))
-
-(defn #^:private
-  statically-disallowed-prerequisite-function-set
-  "To prevent people from mocking functions that Midje itself uses,
-   we mostly rely on dynamic checking. But there are functions within
-   the dynamic checking code that must also not be replaced. These are
-   the ones that are known."
-  [some-var]
-  (#{#'deref #'assoc #'list? #'print #'println} some-var))
 
 (defn assert-right-shape! [[_fake_ funcall & _ :as form]]
   (when-not (or (list? funcall)
@@ -56,6 +50,9 @@
           (error/report-error call-form
                               (cl-format nil "You cannot override the function `~S`: it is inlined by the Clojure compiler." (actual-var)))
 
+          (is-core? (actual-var))
+          (apply error/report-error call-form (disallowed-function-failure-lines (actual-var)))
+
           (and (symbol? fnref) (exposed-testable? (actual-var)))
           (error/report-error call-form
                               "A prerequisite cannot use a symbol exposed via `expose-testables` or `testable-privates`."
@@ -66,10 +63,7 @@
           (error/report-error call-form
                               (cl-format nil "... ~S ~A ~S" call-form arrow result)
                               "Do you really want a checker on the right-hand side of a prerequisite?"
-                              "It's easy to use `truthy` when you meant `true`, etc.")
-
-          (statically-disallowed-prerequisite-function-set (actual-var))
-          (apply error/report-error call-form (disallowed-function-failure-lines (actual-var)))))
+                              "It's easy to use `truthy` when you meant `true`, etc.")))
   [call-form fnref args arrow result overrides])
 
 (defn assert-valid! [form]

--- a/src/midje/util/ecosystem.clj
+++ b/src/midje/util/ecosystem.clj
@@ -74,15 +74,19 @@
   ;; Note that the order is guaranteed: test paths come before project paths.
   (alter-var-root #'leiningen-paths-var
                   (constantly (concat (:test-paths project) (:source-paths project)))))
+
 (defmacro #^:private defproject [name version & {:as args}]
   `(set-leiningen-paths! (merge {:test-paths ["test"] :source-paths ["src"]} '~args)))
+
+(defn- load-project-file []
+  (load-file "project.clj"))
 
 (defn- set-leiningen-paths-from-project-file! []
   (binding [*ns* (find-ns 'midje.util.ecosystem)]
     (try
-      (load-file "project.clj")
+      (load-project-file)
     (catch java.io.FileNotFoundException e
-        (set-leiningen-paths! {:test-paths ["test"]})))))
+      (set-leiningen-paths! {:test-paths ["test"]})))))
 
 (defn leiningen-paths []
   (or leiningen-paths-var

--- a/test/behaviors/t_canary.clj
+++ b/test/behaviors/t_canary.clj
@@ -9,15 +9,16 @@
 
 
 (unfinished favorite-animal)
-(defn favorite-animal-name [] (name (favorite-animal)))
+(def get-name name)
+(defn favorite-animal-name [] (get-name (favorite-animal)))
 (defn favorite-animal-empty [] )
 (defn favorite-animal-only-animal [] (favorite-animal))
-(defn favorite-animal-only-name [] (name "fred"))
+(defn favorite-animal-only-name [] (get-name "fred"))
 
 (fact
      (favorite-animal-name) => "betsy"
      (provided
-       (name (favorite-animal)) => "betsy"))
+       (get-name (favorite-animal)) => "betsy"))
 
 
 
@@ -28,8 +29,8 @@
 (def ...procedure... '...procedure...)
 (defn build-map [exclusion-function]
   (reduce (fn [accumulator name] (conj accumulator {name (exclusion-function name)}))
-	  {}
-	  (all-procedures)))
+          {}
+          (all-procedures)))
 (defn all-procedures-exclude-nothing []
   (build-map (fn [procedure] [])))
 
@@ -46,8 +47,8 @@
   (fact "makes a stream of given day of the month"
     (day-of-month-stream 1) => ?date-time)
 
-	?nth   ?date-time
-        first  (new-date 1 2 3))
+  ?nth   ?date-time
+  first  (new-date 1 2 3))
 
 (defn today-num [])
 

--- a/test/implementation/line_numbers/fim_check_failures.clj
+++ b/test/implementation/line_numbers/fim_check_failures.clj
@@ -10,10 +10,9 @@
 
 
 
-
                    ;;; Simple cases
 
-(def simple-start 16)
+(def simple-start 15)
 
 (silent-fact (+ 1 1) => 3)
 (note-that (failure-was-at-line (+ simple-start 2)))
@@ -41,11 +40,12 @@
                ;;; Inside a deftest
 
 (unfinished favorite-animal)
-(defn favorite-animal-name [] (name (favorite-animal)))
+(def get-name name)
+(defn favorite-animal-name [] (get-name (favorite-animal)))
 (defn return-nil [] )
 (defn favorite-animal-only-animal [] (favorite-animal))
-(defn favorite-animal-only-name [] (name "fred"))
-(defn favorite-animal-one-call [] (name (favorite-animal 1)))
+(defn favorite-animal-only-name [] (get-name "fred"))
+(defn favorite-animal-one-call [] (get-name (favorite-animal 1)))
 
 (def deftest-start 50)
 
@@ -53,14 +53,14 @@
   (fact
     (favorite-animal-name) => "betsy"
     (provided
-      (name (favorite-animal)) => "betsy"))
+      (get-name (favorite-animal)) => "betsy"))
 
   (silent-fact
     (return-nil) => "betsy"   ;; wrong result
     (provided
-      (name (favorite-animal)) => "betsy"))  ;; two prerequisites unfolded here, but never called.
+      (get-name (favorite-animal)) => "betsy"))  ;; two prerequisites unfolded here, but never called.
 
-  (note-that (prerequisite-was-never-called #"name")
+  (note-that (prerequisite-was-never-called #"get-name")
              (prerequisite-was-never-called #"favorite-animal")
              (fact-expected "betsy")
              (failures-were-at-lines  (+ deftest-start 11) (+ deftest-start 11) (+ deftest-start 9)))
@@ -76,19 +76,19 @@
   (silent-fact
    (favorite-animal-only-animal) => "betsy"  ;; here
    (provided
-     (name (favorite-animal)) => "betsy"))   ;; here (name not called)
+     (get-name (favorite-animal)) => "betsy"))   ;; here (get-name not called)
 
-  (note-that (prerequisite-was-never-called #"name")
+  (note-that (prerequisite-was-never-called #"get-name")
              (fact-expected "betsy")
              (failures-were-at-lines (+ deftest-start 29) (+ deftest-start 27)))
 
   (silent-fact
-    (favorite-animal-only-name) => "betsy"   ;; This calls for the name of frank.
+    (favorite-animal-only-name) => "betsy"   ;; This calls for the get-name of frank.
     (provided
-      (name (favorite-animal)) => "betsy"))
+      (get-name (favorite-animal)) => "betsy"))
 
   (note-that some-prerequisite-was-called-with-unexpected-arguments
-             (prerequisite-was-never-called #"name")  ;; never correctly called, I guess I should say.
+             (prerequisite-was-never-called #"get-name")  ;; never correctly called, I guess I should say.
              (prerequisite-was-never-called #"favorite-animal")
              (fact-expected "betsy")
              (failures-were-at-lines (+ deftest-start 38) (+ deftest-start 38) (+ deftest-start 38) (+ deftest-start 36)))
@@ -97,8 +97,8 @@
   (silent-fact
     (favorite-animal-one-call) => "betsy"
     (provided
-      (name (favorite-animal 1)) => "betsy"
-      (name (favorite-animal 2)) => "jake")) ;; a folded prerequisite can have two errors.
+      (get-name (favorite-animal 1)) => "betsy"
+      (get-name (favorite-animal 2)) => "jake")) ;; a folded prerequisite can have two errors.
   (note-that (failures-were-at-lines (+ deftest-start 51) (+ deftest-start 51)))
   (ctf/forget-failures) ;; So clojure.test failures don't show up in summary output.
   )

--- a/test/midje/checking/checkers/t_chatty.clj
+++ b/test/midje/checking/checkers/t_chatty.clj
@@ -5,7 +5,8 @@
             [midje.checking.checkers.defining :refer [checker?]]
             [midje.checking.checkers.chatty :refer [chatty-worth-reporting-on?
                                                     chatty-untease
-                                                    chatty-checker?]]
+                                                    chatty-checker?]
+             :as chatty]
             [midje.test-util :refer :all]))
 (expose-testables midje.checking.checkers.chatty)
 
@@ -30,7 +31,8 @@
 
 (tabular
   (fact "A single argument can be converted into a structured-form and a arg-value-name"
-    (against-background (gensym 'symbol-for-destructured-arg) => 'unique-3)
+    (against-background
+      (#'chatty/gen-destruct-symbol) => 'unique-3)
     (let [[form name] (single-destructuring-arg->form+name ?original)]
       form => ?form
       name => ?name))
@@ -174,7 +176,3 @@
   (fact "`and` and `or`  are still OK, though."
     (macroexpand '(chatty-checker [n] (and 1 2))) =not=> (throws)
     (macroexpand '(chatty-checker [n] (or 1 2))) =not=> (throws)))
-
-
-
-

--- a/test/midje/data/t_prerequisite_state.clj
+++ b/test/midje/data/t_prerequisite_state.clj
@@ -80,7 +80,7 @@
 
   (defn all-even? [xs] (every? even? xs))
 
-  (silent-fact "get a user error from nested call to faked `every?`"
+  (silent-fact "get a parse error from faking a core clojure func"
      (all-even? ..xs..) => truthy
      (provided (every? even? ..xs..) => true))
   (fact
@@ -88,6 +88,11 @@
       text => #"seem to have created a prerequisite"
       text => #"clojure\.core/every\?"
       text => #"interferes with.*Midje"))
+
+  (defn call-rand [] (rand))
+  (fact "get a user error from nested call to faked `every?`"
+    (call-rand) => 1
+    (provided (rand) => 1))
 
 ;; ;; How it works
 

--- a/test/midje/data/t_prerequisite_state.clj
+++ b/test/midje/data/t_prerequisite_state.clj
@@ -1,7 +1,6 @@
 (ns midje.data.t-prerequisite-state
-  (:require [midje
-             [sweet :refer :all]
-             [test-util :refer :all]]
+  (:require [midje.sweet :refer :all]
+            [midje.test-util :refer :all]
             [midje.data.prerequisite-state :refer [binding-map implements-a-fake? usable-default-function?] :as prereq-state]
             [midje.test-util :refer :all]
             [midje.parsing.2-to-lexical-maps.fakes :refer [fake]]
@@ -69,31 +68,17 @@
     (provided
       (internal 1) => -33))
 
-
-  ;; The same thing can be done with clojure.core functions
-
-  (defn double-partition [first-seq second-seq]
-    (concat (partition-all 1 first-seq) (partition-all 1 second-seq)))
-
-  (fact (double-partition [1 2] [3 4]) => [ [1] [2] [3] [4] ])
-
-  (fact
-    (double-partition [1 2] ..xs..) => [[1] [2] [..x1..] [..x2..]]
-    (provided (partition-all 1 ..xs..) => [ [..x1..] [..x2..] ]))
-
-
-  ;; However you can't override functions that are used by Midje itself
+  ;; However you can't override `clojure.core` functions because they might be
+  ;; used by Midje itself.
   ;; These are reported thusly:
 
   (defn message-about-mocking-midje-functions [reported]
     (let [important-error
-          (shorthand/find-first #(= (:type %) :actual-result-did-not-match-checker)
+          (shorthand/find-first #(= (:type %) :parse-error)
                                 reported)]
-      (and important-error
-           (.getMessage (.throwable (:actual important-error))))))
+      (->> important-error :notes (clojure.string/join " "))))
 
   (defn all-even? [xs] (every? even? xs))
-
 
   (silent-fact "get a user error from nested call to faked `every?`"
      (all-even? ..xs..) => truthy
@@ -103,7 +88,6 @@
       text => #"seem to have created a prerequisite"
       text => #"clojure\.core/every\?"
       text => #"interferes with.*Midje"))
-
 
 ;; ;; How it works
 

--- a/test/midje/data/t_project_state.clj
+++ b/test/midje/data/t_project_state.clj
@@ -1,7 +1,7 @@
 (ns midje.data.t-project-state
   (:require [midje.sweet :refer :all]
             [midje.test-util :refer :all]
-            [midje.data.project-state :refer :all]
+            [midje.data.project-state :refer :all :as project-state]
             [midje.util.ecosystem :as ecosystem]
             [midje.util.bultitude :as tude]
             [clojure.java.io :as io]))
@@ -67,25 +67,23 @@
 
 
 (fact "A namespace list can be loaded, obeying dependents"
-  (require-namespaces! [] record-failure cleaner) => anything
+  (#'project-state/require-namespaces! [] record-failure cleaner) => anything
 
-  (require-namespaces! [..ns1.. ..ns2..] record-failure cleaner) => anything
+  (#'project-state/require-namespaces! [..ns1.. ..ns2..] record-failure cleaner) => anything
   (provided
-    (require ..ns1.. :reload) => nil
-    (require ..ns2.. :reload) => nil)
+    (#'project-state/load-failure ..ns1..) => nil
+    (#'project-state/load-failure ..ns2..) => nil)
 
-  (require-namespaces! [..ns1.. ..ns2..] record-failure cleaner) => anything
+  (#'project-state/require-namespaces! [..ns1.. ..ns2..] record-failure cleaner) => anything
   (provided
-    (require ..ns1.. :reload) => nil
-    (require ..ns2.. :reload) => nil)
-
-
+    (#'project-state/load-failure ..ns1..) => nil
+    (#'project-state/load-failure ..ns2..) => nil)
 
   (let [throwable (Error.)]
-    (require-namespaces! [..ns1.. ..ns2.. ..ns3..] record-failure cleaner) => anything
+    (#'project-state/require-namespaces! [..ns1.. ..ns2.. ..ns3..] record-failure cleaner) => anything
     (provided
-      (require ..ns1.. :reload) =throws=> throwable
+      (#'project-state/load-failure ..ns1..) => throwable
       (cleaner ..ns1.. [..ns2.. ..ns3..]) => [..ns3..]
-      (require ..ns3.. :reload) => nil)
+      (#'project-state/load-failure ..ns3..) => nil)
     @failure-record => {:ns ..ns1.. :throwable throwable}))
 

--- a/test/midje/emission/t_api.clj
+++ b/test/midje/emission/t_api.clj
@@ -7,20 +7,6 @@
             [midje.emission.plugins.test-support :as plugin]
             [midje.config :as config]))
 
-(fact load-plugin
-  (fact "symbols are required"
-    (emit/load-plugin 'symbol) => irrelevant
-    (provided
-      (require 'symbol :reload) => anything))
-
-  (fact "strings are given to load-file"
-    (emit/load-plugin "string") => irrelevant
-    (provided
-      (load-file "string") => anything)))
-
-
-
-
 (defmacro innocuously [& body]
   `(without-changing-cumulative-totals
     (state/with-emission-map plugin/emission-map

--- a/test/midje/parsing/2_to_lexical_maps/t_expects.clj
+++ b/test/midje/parsing/2_to_lexical_maps/t_expects.clj
@@ -203,10 +203,13 @@
   (midje.parsing.2-to-lexical-maps.expects/expect (chatty-fut 5) => "hello"
           (fake (chatty-prerequisite (actual-plus-one-is-greater-than 5)) => "hello")))
 
-(fact "you can fake a function from another namespace"
-  (let [myfun (fn [x] (list x))]
-    (midje.parsing.2-to-lexical-maps.expects/expect (myfun 1) => :list-called
-            (fake (list 1) => :list-called))))
+
+(def listy list)
+(let [myfun (fn [x] (listy x))]
+  (fact "you can fake a function from another namespace"
+      (midje.parsing.2-to-lexical-maps.expects/expect
+        (myfun 1) => :list-called
+        (fake (listy 1) => :list-called))))
 
 (defn set-handler [set1 set2]
   (if (empty? (intersection set1 set2))

--- a/test/midje/util/t_ecosystem.clj
+++ b/test/midje/util/t_ecosystem.clj
@@ -1,6 +1,6 @@
 (ns midje.util.t-ecosystem
   (:require [midje.sweet :refer :all]
-            [midje.util.ecosystem :refer :all]
+            [midje.util.ecosystem :refer :all :as ecosystem]
             [midje.test-util :refer :all]))
 
 (fact "can find paths to load from project.clj"
@@ -15,7 +15,7 @@
   (fact "and provides a default if it does not"
     (leiningen-paths) => ["test"]
     (provided
-      (load-file "project.clj") =throws=> (new java.io.FileNotFoundException)))
+      (#'ecosystem/load-project-file) =throws=> (new java.io.FileNotFoundException)))
 
   (fact "except that lein-midje can explicitly set the value"
     (set-leiningen-paths! {:test-paths ["t"] :source-paths ["s"]})

--- a/test/user/fus_parse_errors.clj
+++ b/test/user/fus_parse_errors.clj
@@ -24,6 +24,12 @@
     (+ 3 3) => 0))
 (note-that parse-error-found (fact-failed-with-note #"clojure.core/\+.*is inlined"))
 
+(silent-fact "clojure.core functions cannot be faked"
+  (f 3) => 0
+  (provided
+    (set [3]) => 0))
+(note-that parse-error-found (fact-failed-with-note #"You seem to have created a prerequisite for.*set"))
+
 (silent-fact "the left-hand side must look like a function call"
   (f) => 0
   (provided
@@ -186,8 +192,9 @@
    @fact-output => #"\(first :facts identity\) does not look like"))
 
 
+(unfinished foo)
 (fact ;; prerequisite forms don't object to prerequisite arrows
-  (prerequisite (rand) =streams=> [1 2 3])
+  (prerequisite (foo) =streams=> [1 2 3])
   1 => 1)
 
 ;;; =====================================              Outside-fact against-background


### PR DESCRIPTION
In https://github.com/marick/Midje/pull/433 I added the use of `set` in some code that is executed while functions being faked are redefined to the fake. This means if you add a fake for `clojure.core/set`, it will break Midje.

One way around this is to add `set` to the blacklist here https://github.com/phillipm/Midje/blob/5c80966287707f7d3f92ab417843698cbbca59be/src/midje/parsing/2_to_lexical_maps/fakes.clj#L26
This approach is not good for the maintanability and stability of Midje, because somebody might forget to do so. For instance, I discovered that I should have added `set` to the blacklist only after encountering a strange test failure in a production service. Imagine how confused one might be if they discovered this issue before I fixed it! 

Thus, I propose that we disallow faking of any function defined in `clojure.core`. This adds limitations to what Midje is capable of, but is much safer, and I personally think that one should really avoid mocking core language constructs.
  
  