### PR TITLE
Show exceptions raised in checker logic to user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 This project adheres to [Semantic Versioning](http://semver.org/).
 See [here](http://keepachangelog.com/) for the change log format.
 
+## [1.9.2-alpha3] - 2018-02-21
+- 436: Show exceptions raised by checker functions
+
 ## [1.9.2-alpha2] - 2018-01-03
 - 431: __POTENTIALLY BREAKING__ Fix issue where you can fake functions with incorrect arities. Function faking now produces a test failure if you provide more or less arguments than expected by the function definition. This may break tests that incorrectly faked functions, but this is a good thing because it will reveal bugs in your tests.
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Stable version:
 Experimental version:
 
 ```clojure
-[midje "1.9.2-alpha1"]
+[midje "1.9.2-alpha3"]
 ```
 
 License: [MIT](http://en.wikipedia.org/wiki/MIT_License)

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject midje "1.9.2-alpha2"
+(defproject midje "1.9.2-alpha3"
   :description "A TDD library for Clojure that supports top-down ('mockish') TDD, encourages readable tests, provides a smooth migration path from clojure.test, balances abstraction and concreteness, and strives for graciousness."
   :url "https://github.com/marick/Midje"
   :pedantic? :warn

--- a/src/midje/checking/checkables.clj
+++ b/src/midje/checking/checkables.clj
@@ -29,10 +29,17 @@
   {:notes [(inherently-false-map-to-record-comparison-note actual expected)]})
 
 (defn- check-for-match [actual checkable-map]
-  (let [expected      (:expected-result checkable-map)
+  (let [expected (:expected-result checkable-map)
         [check-result failure-details] (detailed-extended-= actual expected)]
     (cond check-result
           (emit/pass)
+
+          ;; checker logic threw an exception
+          (:thrown failure-details)
+          (emit/fail (merge (minimal-failure-map :checker-exception
+                                                 actual checkable-map)
+                            failure-details))
+
 
           (has-function-checker? checkable-map)
           (emit/fail (merge (minimal-failure-map :actual-result-did-not-match-checker

--- a/src/midje/checking/checkables.clj
+++ b/src/midje/checking/checkables.clj
@@ -56,12 +56,19 @@
 
 
 (defn- check-for-mismatch [actual checkable-map]
-  (let [expected (:expected-result checkable-map)]
+  (let [expected (:expected-result checkable-map)
+        [check-result failure-details] (detailed-extended-= actual expected)]
     (cond (inherently-false-map-to-record-comparison? actual expected)
           (emit/fail (merge (minimal-failure-map :actual-result-should-not-have-matched-expected-value actual checkable-map)
                             (map-record-mismatch-addition actual expected)))
 
-          (not (extended-= actual expected))
+          ;; checker logic threw an exception
+          (:thrown failure-details)
+          (emit/fail (merge (minimal-failure-map :checker-exception
+                                                 actual checkable-map)
+                            failure-details))
+
+          (not check-result)
           (emit/pass)
 
           (has-function-checker? checkable-map)

--- a/src/midje/checking/core.clj
+++ b/src/midje/checking/core.clj
@@ -47,8 +47,8 @@
       (if (data-laden-falsehood? function-result)
         [false function-result]
         [function-result {}]))
-  (catch Throwable ex
-    [false {:thrown ex}])))
+    (catch Throwable ex
+      [false {:thrown ex}])))
 
 (defn detailed-extended-=
   "Equality check that can handle checker functions and compare arguments of

--- a/src/midje/emission/plugins/default_failure_lines.clj
+++ b/src/midje/emission/plugins/default_failure_lines.clj
@@ -4,6 +4,7 @@
             [clojure.pprint :refer [cl-format]]
             [flare.core :as flare]
             [midje.emission.plugins.util :refer :all]
+            [midje.util.exceptions :as exceptions]
             [midje.util.ecosystem :as ecosystem]))
 
 (defmulti messy-lines :type)
@@ -71,6 +72,10 @@
       (str "Actual result:\n" (attractively-stringified-value (:actual m)))
       (str "Checking function: " (:expected-result-form m))))
 
+(defmethod messy-lines :checker-exception [m]
+    (list
+      (str "The checking function `" (:expected-result-form m) "` threw the exception:\n")
+      (exceptions/friendly-exception (:thrown m))))
 
 (defmethod messy-lines :some-prerequisites-were-called-the-wrong-number-of-times [m]
   (letfn [(format-one-failure [fail]

--- a/src/midje/emission/plugins/default_failure_lines.clj
+++ b/src/midje/emission/plugins/default_failure_lines.clj
@@ -4,7 +4,6 @@
             [clojure.pprint :refer [cl-format]]
             [flare.core :as flare]
             [midje.emission.plugins.util :refer :all]
-            [midje.util.exceptions :as exceptions]
             [midje.util.ecosystem :as ecosystem]))
 
 (defmulti messy-lines :type)
@@ -75,7 +74,7 @@
 (defmethod messy-lines :checker-exception [m]
     (list
       (str "The checking function `" (:expected-result-form m) "` threw the exception:")
-      (exceptions/friendly-exception (:thrown m))
+      (attractively-stringified-value (:thrown m))
       (str "\nWhen checked against the actual result:\n" (attractively-stringified-value (:actual m)))))
 
 (defmethod messy-lines :some-prerequisites-were-called-the-wrong-number-of-times [m]

--- a/src/midje/emission/plugins/default_failure_lines.clj
+++ b/src/midje/emission/plugins/default_failure_lines.clj
@@ -74,8 +74,9 @@
 
 (defmethod messy-lines :checker-exception [m]
     (list
-      (str "The checking function `" (:expected-result-form m) "` threw the exception:\n")
-      (exceptions/friendly-exception (:thrown m))))
+      (str "The checking function `" (:expected-result-form m) "` threw the exception:")
+      (exceptions/friendly-exception (:thrown m))
+      (str "\nWhen checked against the actual result:\n" (attractively-stringified-value (:actual m)))))
 
 (defmethod messy-lines :some-prerequisites-were-called-the-wrong-number-of-times [m]
   (letfn [(format-one-failure [fail]

--- a/src/midje/util/exceptions.clj
+++ b/src/midje/util/exceptions.clj
@@ -45,6 +45,9 @@
       (concat ["" (str prefix "Caused by: " message)]
               stacktrace))))
 
+(defn friendly-exception [ex]
+  (join line-separator (friendly-exception-lines ex "  ")))
+
 (defn user-error-exception-lines [throwable]
   (cons (str throwable)
     (without-clojure-strings (stacktrace-as-strings throwable))))
@@ -60,7 +63,7 @@
   ICapturedThrowable
   (throwable [this] ex)
   (friendly-stacktrace [this]
-    (join line-separator (friendly-exception-lines (throwable this) "  "))))
+    (friendly-exception (throwable this))))
 
 (defn captured-throwable [ex]
   (CapturedThrowable. ex))

--- a/src/midje/util/exceptions.clj
+++ b/src/midje/util/exceptions.clj
@@ -45,9 +45,6 @@
       (concat ["" (str prefix "Caused by: " message)]
               stacktrace))))
 
-(defn friendly-exception [ex]
-  (join line-separator (friendly-exception-lines ex "  ")))
-
 (defn user-error-exception-lines [throwable]
   (cons (str throwable)
     (without-clojure-strings (stacktrace-as-strings throwable))))
@@ -63,7 +60,7 @@
   ICapturedThrowable
   (throwable [this] ex)
   (friendly-stacktrace [this]
-    (friendly-exception (throwable this))))
+    (join line-separator (friendly-exception-lines (throwable this) "  "))))
 
 (defn captured-throwable [ex]
   (CapturedThrowable. ex))

--- a/test/midje/checking/checkers/t_collection.clj
+++ b/test/midje/checking/checkers/t_collection.clj
@@ -269,8 +269,13 @@
   (data-laden-falsehood-to-map ( (has-prefix 1) {:a 1}))
   => (contains {:actual {:a 1} :notes ["Maps don't have prefixes."]})
   (data-laden-falsehood-to-map ( (has-suffix 1) {:a 1}))
-  => (contains {:actual {:a 1} :notes ["Maps don't have suffixes."]})
-  )
+  => (contains {:actual {:a 1} :notes ["Maps don't have suffixes."]}))
+
+(fact "contains expecting a list but passed a map throws an excpetion"
+  ;; TODO PLM: the exceptions thrown by `contains` here are very unhelpful
+  ((contains {:a 1} {:a 2}) {:a 2}) => (throws Exception)
+  ((contains [{:a 1} {:a 2}] :in-any-order) {:a 2}) => (throws Exception)
+  ((contains [{:a 2} {:a 1}] :in-any-order) {:a 2}) => (throws Exception))
 
 (fact "left-hand-side: maps"
  {:a 1, :b 2} => (contains {:a 1, :b 2})
@@ -281,9 +286,6 @@
  {:a 2}   => (contains {:a 2})
  {:a 2}   => (contains [{:a 2}])
  [{:a 2}] => (contains [{:a 2}])
- {:a 2} =not=> (contains {:a 1} {:a 2})
- {:a 2} =not=> (contains [{:a 1} {:a 2}] :in-any-order)
- {:a 2} =not=> (contains [{:a 2} {:a 1}] :in-any-order)
  ( (contains {:a 1, :b 2, :c 2}) {:a 1, :b 2}) => falsey
  ( (contains {:a 1, :c 2}) {:a 1, :b 2}) => falsey
  ( (contains {:a 1, :b 'not-2}) {:a 1, :b 2}) => falsey

--- a/test/midje/t_sweet.clj
+++ b/test/midje/t_sweet.clj
@@ -389,9 +389,12 @@
    (#'midje.data.t-prerequisite-state/var-inc
     (#'midje.data.t-prerequisite-state/var-inc 2)) => 201))
 
- (fact "exceptions do not blow up"
-   (odd? "foo") => (throws Exception)
-   "foo" =not=> odd?)
+(fact "exceptions do not blow up"
+ (odd? "foo") => (throws Exception))
+
+(silent-fact
+  "baz" =not=> odd?)
+(fact-failed-with-note #"The checking function `odd?` threw the exception:")
 
 ;;; fact groups
 

--- a/test/midje/t_sweet.clj
+++ b/test/midje/t_sweet.clj
@@ -396,6 +396,10 @@
   "baz" =not=> odd?)
 (fact-failed-with-note #"The checking function `odd?` threw the exception:")
 
+(silent-fact
+  (throw (ex-info "foo" {})) =not=> even?)
+(fact-failed-with-note #"The checking function `even?` threw the exception:")
+
 ;;; fact groups
 
 (fact-group :integration {:timing 3}

--- a/test/user/fus_prerequisites__missing.clj
+++ b/test/user/fus_prerequisites__missing.clj
@@ -9,7 +9,7 @@
 (capturing-failure-output
  (fact "Midje seems to have a problem with lazyseqs"
    (-> (map pre-process [..metaconstant..])
-       process) => ..processed..
+       process) => #(= ..processed.. %)
        (provided
          (pre-process ..metaconstant..) => ..intermediate..
          (process [..intermediate..]) => ..processed..))
@@ -19,5 +19,4 @@
    @fact-output => #"an unrealized lazy sequence"
    @fact-output => #"pre-process.*never called"
    @fact-output => #"process.*never called"
-   @fact-output => #"Expected:\n\.\.processed\.\."
    @fact-output => #"`process` returned this string"))


### PR DESCRIPTION
Addresses https://github.com/marick/Midje/issues/436

Before
```
user=> (fact "baz" => even?)

FAIL at (form-init3908360799319285420.clj:2)
Actual result did not agree with the checking function.
Actual result:
"baz"
Checking function: even?
```

After
```
user=> (fact "baz" => even?)

FAIL at (form-init5640994841513193915.clj:2)
The checking function `even?` threw the exception:
java.lang.IllegalArgumentException: Argument must be an integer: baz

When checked against the actual result:
"baz"
```