### PR TITLE
Adding irrelevant-value checker

### DIFF
--- a/src/midje/checkers.clj
+++ b/src/midje/checkers.clj
@@ -21,7 +21,7 @@
                        [midje.checking.checkers.chatty
                           chatty-checker]
                        [midje.checking.checkers.simple
-                          truthy falsey TRUTHY FALSEY anything irrelevant exactly throws roughly]
+                          truthy falsey TRUTHY FALSEY anything irrelevant irrelevant-value exactly throws roughly]
                        [midje.checking.checkers.combining
                           every-checker some-checker]
                        [midje.checking.checkers.collection

--- a/src/midje/checking/checkers/simple.clj
+++ b/src/midje/checking/checkers/simple.clj
@@ -32,7 +32,7 @@
 (ns/defalias irrelevant anything)
 
 (defchecker irrelevant-value
-  "Accpets any value (doesn't accept functions"
+  "Accepts any value but functions"
   [actual]
   (and (not (captured-throwable? actual)) (not (fn? actual))))
 

--- a/src/midje/checking/checkers/simple.clj
+++ b/src/midje/checking/checkers/simple.clj
@@ -31,6 +31,11 @@
   (not (captured-throwable? actual)))
 (ns/defalias irrelevant anything)
 
+(defchecker irrelevant-value
+  "Accpets any value (doesn't accept functions"
+  [actual]
+  (and (not (captured-throwable? actual)) (not (fn? actual))))
+
 (defchecker exactly
   "Checks for equality. Use to avoid default handling of functions."
   [expected]

--- a/test/midje/checking/checkers/t_simple.clj
+++ b/test/midje/checking/checkers/t_simple.clj
@@ -31,7 +31,11 @@
   false => anything
   even? => anything
   "irrelevant is a synonym"
-  1 => irrelevant)
+  1 => irrelevant
+  "irrelevant-value doesn't accept functions"
+  (fn []) =not=> irrelevant-value
+  3 => irrelevant-value
+  {} => irrelevant-value)
 
 (facts "about exactly"
   #'exactly => checker?


### PR DESCRIPTION
Adding this checker because we faced a situation where we didn't catch a bug because the test was broken it wasn't testing anything. eg
```clojure
(partial my-side-effect-fn! arg) => irrelevant
```
this could be easily solved using this new checker:

```clojure
(partial my-side-effect-fn arg) => irrelevant-value  ;;this would make the fact around it fail