### PR TITLE
Stop treating exceptions in for-all as passing tests

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -7,7 +7,7 @@
                  [org.clojure/math.combinatorics "0.1.4"]
                  [io.aviso/pretty "0.1.34"]
                  [org.clojure/core.unify "0.5.7" :exclusions [org.clojure/clojure]]
-                 [org.clojure/test.check "0.9.0"]
+                 [org.clojure/test.check "0.10.0-alpha3"]
                  [clj-time "0.14.2" :exclusions [org.clojure/clojure]]
                  [colorize "0.1.1" :exclusions [org.clojure/clojure]]
                  [org.clojure/tools.macro "0.1.5"]

--- a/src/midje/parsing/0_to_fact_form/generative.clj
+++ b/src/midje/parsing/0_to_fact_form/generative.clj
@@ -79,11 +79,11 @@
              [run# passes#] (run-for-all (list ~num-tests
                                                prop#
                                                ~@quick-check-opts))]
-         (if (:result run#)
+         (if (:pass? run#)
            (dotimes [_# (/ passes# ~num-tests)]
              (emission/pass))
            (run-with-smallest fact-fn# '~prop-names run#))
-         (boolean (:result run#))))))
+         (:pass? run#)))))
 
 (defn parse-for-all [form]
   (error/parse-and-catch-failure form (build-parser form)))

--- a/test/behaviors/t_for_all.clj
+++ b/test/behaviors/t_for_all.clj
@@ -10,22 +10,19 @@
 (silent-for-all
   [strictly-pos gen/s-pos-int
    any-integer  gen/int]
-  {:seed 1510160943861}
   (fact (+ strictly-pos any-integer) => pos?))
-(note-that fact-fails (failure-was-at-line 14))
+(note-that fact-fails (failure-was-at-line 13))
 
 (silent-for-all
   [strictly-pos gen/s-pos-int
    any-integer  gen/int]
-  {:seed 1510160943861}
   (fact 1 => 1)
   (+ strictly-pos any-integer) => pos?)
-(note-that fact-fails (failure-was-at-line 22))
+(note-that fact-fails (failure-was-at-line 20))
 
 (silent-for-all "generative tests"
   [strictly-pos gen/s-pos-int
    any-integer  gen/int]
-  {:seed 1510160943861}
   (fact "Summing an integer to a positive integer should be positive? Really?"
     strictly-pos => integer?
     (+ strictly-pos any-integer) => pos?))
@@ -34,7 +31,6 @@
 (def pass-count (state/output-counters:midje-passes))
 (for-all
   [strictly-pos gen/s-pos-int]
-  {:seed 3510160943861}
   (+ strictly-pos 0) => pos?
   (let [an-int 0]
     (fact "I. you can wrap your facts in `let`"

--- a/test/behaviors/t_for_all.clj
+++ b/test/behaviors/t_for_all.clj
@@ -10,19 +10,22 @@
 (silent-for-all
   [strictly-pos gen/s-pos-int
    any-integer  gen/int]
+  {:num-tests 100}
   (fact (+ strictly-pos any-integer) => pos?))
-(note-that fact-fails (failure-was-at-line 13))
+(note-that fact-fails (failure-was-at-line 14))
 
 (silent-for-all
   [strictly-pos gen/s-pos-int
    any-integer  gen/int]
+  {:num-tests 100}
   (fact 1 => 1)
   (+ strictly-pos any-integer) => pos?)
-(note-that fact-fails (failure-was-at-line 20))
+(note-that fact-fails (failure-was-at-line 22))
 
 (silent-for-all "generative tests"
   [strictly-pos gen/s-pos-int
    any-integer  gen/int]
+  {:num-tests 100}
   (fact "Summing an integer to a positive integer should be positive? Really?"
     strictly-pos => integer?
     (+ strictly-pos any-integer) => pos?))

--- a/test/behaviors/t_for_all.clj
+++ b/test/behaviors/t_for_all.clj
@@ -33,26 +33,24 @@
 
 (def pass-count (state/output-counters:midje-passes))
 (for-all
-  [strictly-pos gen/s-pos-int
-   any-integer  gen/int]
+  [strictly-pos gen/s-pos-int]
   {:seed 3510160943861}
-  (+ strictly-pos any-integer) => pos?
+  (+ strictly-pos 0) => pos?
   (let [an-int 0]
     (fact "I. you can wrap your facts in `let`"
-      (+ an-int strictly-pos any-integer) => pos?))
+      (+ an-int strictly-pos) => pos?))
   (let [an-int 1]
     (fact "II. you can wrap your facts in `let`"
-      (+ an-int strictly-pos any-integer) => pos?)))
+      (+ an-int strictly-pos) => pos?)))
 
 (fact
   (state/output-counters:midje-passes) => (+ pass-count 3))
 
 (for-all "random map not confounded with quick-check options if in correct place"
-  [strictly-pos gen/s-pos-int
-   any-integer  gen/int]
+  [strictly-pos gen/s-pos-int]
   {:seed 3510160943861}
   {:some 'random :map '.}
-  (fact (+ strictly-pos any-integer) => pos?))
+  (fact (+ strictly-pos 0) => pos?))
 
 (silent-for-all "confounding random map with quick-check options"
   [strictly-pos gen/s-pos-int

--- a/test/behaviors/t_for_all.clj
+++ b/test/behaviors/t_for_all.clj
@@ -10,14 +10,14 @@
 (silent-for-all
   [strictly-pos gen/s-pos-int
    any-integer  gen/int]
-  {:num-tests 100}
+  {:num-tests 1000}
   (fact (+ strictly-pos any-integer) => pos?))
 (note-that fact-fails (failure-was-at-line 14))
 
 (silent-for-all
   [strictly-pos gen/s-pos-int
    any-integer  gen/int]
-  {:num-tests 100}
+  {:num-tests 1000}
   (fact 1 => 1)
   (+ strictly-pos any-integer) => pos?)
 (note-that fact-fails (failure-was-at-line 22))
@@ -25,7 +25,7 @@
 (silent-for-all "generative tests"
   [strictly-pos gen/s-pos-int
    any-integer  gen/int]
-  {:num-tests 100}
+  {:num-tests 1000}
   (fact "Summing an integer to a positive integer should be positive? Really?"
     strictly-pos => integer?
     (+ strictly-pos any-integer) => pos?))

--- a/test/behaviors/t_for_all.clj
+++ b/test/behaviors/t_for_all.clj
@@ -126,6 +126,16 @@
       run again"
   @my-inc-count => 2)
 
+(def pass-count (state/output-counters:midje-passes))
+(try
+  (silent-for-all
+    [x gen/int]
+    (fact "Exceptions that occur in fact set up should propagate up and not cause a passing test."
+      (/ 1 0)
+      x => integer?))
+  (catch java.lang.ArithmeticException e))
+(fact (state/output-counters:midje-passes) => pass-count)
+
 (def gen-count (atom 0))
 (def gen-int-with-count
   (gen/sized (fn [size]


### PR DESCRIPTION
### Fix for-all tests that only work for hard-coded seed

There were two tests in the t_for_all tests that shouldn't pass logically, but
happen to pass for the given seed. I believe this was done in error, so I
removed the logical errors from the tests


### Stop swallowing exceptions in for-all fact setup

Previously when an exception occured in a for-all fact but not in a checkable,
the exception was silently swallowed and the fact returned true. This happened
because the generative form was checking against the truthiness of the value in
the quick-check response under the key `:result`. But when an exception happened
the `:result` was an exception object, not `false` so generative midje form
proceeded as if the test had passed.

In this commit I've updated the test.check version to 0.10.0-alpha3 because a
`:pass?` key has been added to the `quick-check` response map which we can use
more accurately check the run state. Here is the commit where the `:pass?` key
was added:
clojure/test.check@09927b6

The test.check version we were using (0.9.0) was released in Nov 2015. The
new 0.10.0-alpha3 was released May 2018. Here is the changelog for test.check:
https://github.com/clojure/test.check/blob/master/CHANGELOG.markdown

I believe that its beneficial to stay up to date with changes in test.check, but
I can understand if people are wary of depending on an alpha version of
test.check, and I could find a different way to check for fix this problem
without updating the dependency if it needs to be done.