### PR TITLE
JDK 11 fixes

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -15,7 +15,8 @@
                  [org.clojure/tools.namespace "0.3.0-alpha4"]
                  [flare "0.2.9" :exclusions [org.clojure/clojure]]
                  [slingshot "0.12.2"]
-                 [mvxcvi/puget "1.0.2" :exclusions [org.clojure/clojure]]]
+                 [mvxcvi/puget "1.0.2" :exclusions [org.clojure/clojure fipp]]
+                 [fipp "0.6.13"]]
   :profiles {:dev {:dependencies [[prismatic/plumbing "0.5.5"]]
                    :plugins [[lein-midje "3.2.1"]
                              [lein-ancient "0.6.15" :exclusions [com.fasterxml.jackson.core/jackson-databind

--- a/src/midje/util/ordered_set.clj
+++ b/src/midje/util/ordered_set.clj
@@ -72,7 +72,7 @@
     (.count this))
   (isEmpty [this]
     (zero? (.count this)))
-  (toArray [this dest]
+  (^objects toArray [this ^objects dest]
     (reduce (fn [idx item]
               (aset dest idx item)
               (inc idx))


### PR DESCRIPTION
In JDK 11, toArray with a 1-arity is now ambiguous so a type hint is needed
to disambiguate. This commit fixes this in ordered-set and also arranges
(by using the latest fipp which uses the latest rrb-vector which fixes the
same problem in rrb-vector).