### PR TITLE
Print linebreaks in failure messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 This project adheres to [Semantic Versioning](http://semver.org/).
 See [here](http://keepachangelog.com/) for the change log format.
 
+## [1.9.6] - 2019-01-16
+- correctly print linebreaks in failure messages
+
 ## [1.9.5] - 2019-01-08
 - Introduce `midje.experimental/gen-let` macro for combining generative matchers
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject midje "1.9.5"
+(defproject midje "1.9.6"
   :description "A TDD library for Clojure that supports top-down ('mockish') TDD, encourages readable tests, provides a smooth migration path from clojure.test, balances abstraction and concreteness, and strives for graciousness."
   :url "https://github.com/marick/Midje"
   :pedantic? :warn

--- a/src/midje/emission/plugins/util.clj
+++ b/src/midje/emission/plugins/util.clj
@@ -183,7 +183,7 @@
      - notes on which bindings were supplied to a tabular fact"
   [m]
   (let [description (when-let [doc (format-nested-descriptions (:description m))]
-                      (str (pr-str doc) " "))
+                      (str doc " "))
         position (position-str (:position m) (:namespace m))
         table-substitutions (when (:midje/table-bindings m)
                               (str "With table substitutions: " (format-binding-map (:midje/table-bindings m))))]

--- a/src/midje/emission/plugins/util.clj
+++ b/src/midje/emission/plugins/util.clj
@@ -1,5 +1,5 @@
-(ns ^{:doc "General purpose plugin utilities"}
-  midje.emission.plugins.util
+(ns midje.emission.plugins.util
+  "General purpose plugin utilities"
   (:require [clojure.repl :refer [demunge]]
             [clojure.string :as str]
             [puget.printer :as puget]
@@ -177,10 +177,10 @@
 
 
 (defn failure-notice
-  "The reader's eye is guided by a bright red FAIL, the filename and lineno, and
+  "The reader's eye is guided by a bright red FAIL, the filename and line-number, and
    perhaps this other information:
-     : the descriptions of all enclosing facts, if any
-     : notes on which bindings were supplied to a tabular fact"
+     - the descriptions of all enclosing facts, if any
+     - notes on which bindings were supplied to a tabular fact"
   [m]
   (let [description (when-let [doc (format-nested-descriptions (:description m))]
                       (str (pr-str doc) " "))

--- a/test/midje/emission/plugins/t_util.clj
+++ b/test/midje/emission/plugins/t_util.clj
@@ -69,7 +69,9 @@
   (failure-notice {:position ["filename" 10]})
   => (just #"FAIL\S* at \(filename:10\)" nil)
   (failure-notice {:position ["filename" 10] :description ["outer" nil "inner"]})
-  => (just #"FAIL\S* \"outer - inner\" at \(filename:10\)" nil)
+  => (just #"FAIL\S* outer - inner at \(filename:10\)" nil)
+  (failure-notice {:position ["filename" 10] :description ["multi\nline" nil "inner"]})
+  => (just #"FAIL\S* multi\nline - inner at \(filename:10\)" nil)
   (failure-notice {:position ["filename" 10] :midje/table-bindings '{?a 1}})
   => (just #"FAIL\S* at \(filename:10\)"
            "With table substitutions: [?a 1]")


### PR DESCRIPTION
resolves https://github.com/marick/Midje/issues/453


When running 
```clojure
(fact "foo
bar"
  (fact "baz"
    1 => 2))
```

The error message before:
```
FAIL "foo\nbar - baz" at (t_util.clj:64)
Expected:
2
Actual:
1
```

and after:
```
FAIL foo
bar - baz at (t_util.clj:64)
Expected:
2
Actual:
1
```