### PR TITLE
Improving control of colorize

### DIFF
--- a/src/midje/bootstrap.clj
+++ b/src/midje/bootstrap.clj
@@ -12,6 +12,7 @@
       (try
         (in-ns 'midje.config)
         ((ns-resolve 'midje.config 'load-config-files))
+        ((ns-resolve 'midje.config 'load-env-vars))
       (finally
         (in-ns saved-ns))))
 

--- a/src/midje/bootstrap.clj
+++ b/src/midje/bootstrap.clj
@@ -1,7 +1,6 @@
 (ns midje.bootstrap
   (:require [midje.config :as config]
             [midje.emission.api :as emission.api]
-            [midje.emission.colorize :as emission.colorize]
             [midje.emission.state :as emission.state]))
 
 (defonce bootstrapped false)
@@ -17,7 +16,6 @@
         (in-ns saved-ns))))
 
     (emission.api/load-plugin (config/choice :emitter))
-    (emission.colorize/init!)
     (emission.state/no-more-plugin-installation)
 
     (alter-var-root #'bootstrapped (constantly true))))

--- a/src/midje/emission/colorize.clj
+++ b/src/midje/emission/colorize.clj
@@ -20,22 +20,21 @@
   (str/upper-case (or (ecosystem/getenv "MIDJE_COLORIZE")
                       (config-choice-as-string))))
 
-(defn init! []
-  (case (colorize-string)
-    "TRUE"
-    (do
-      (def fail color/red)
-      (def pass color/green)
-      (def note color/cyan))
+(defmacro ^:private def-colorize
+  [fn-name on reverse]
+  `(defn ~fn-name
+     [s#]
+     ((case (colorize-string)
+        "TRUE" ~on
+        "REVERSE" ~reverse
+        str)
+      s#)))
 
-    "REVERSE"
-    (do
-      (def fail color/red-bg)
-      (def pass color/green-bg)
-      (def note color/cyan-bg))
+(def-colorize fail
+  color/red color/red-bg)
 
-    ;; else
-    (do
-      (def fail str)
-      (def pass str)
-      (def note str))))
+(def-colorize pass
+  color/green color/green-bg)
+
+(def-colorize note
+  color/cyan color/cyan-bg)

--- a/src/midje/emission/colorize.clj
+++ b/src/midje/emission/colorize.clj
@@ -8,21 +8,17 @@
 ;; file can fake the prerequisite
 (def config-choice config/choice)
 
-(defmacro ^:private def-colorize
-  [fn-name on reverse]
-  `(defn ~fn-name
-     [& s#]
-     (apply (case (config-choice :colorize)
-              :true ~on
-              :reverse ~reverse
-              str)
-            s#)))
+(defn- build-colorizer
+  [normal-color reverse-color]
+  (fn [& s]
+    (apply (case (config-choice :colorize)
+             :true normal-color
+             :reverse reverse-color
+             str)
+           s)))
 
-(def-colorize fail
-  color/red color/red-bg)
+(def fail (build-colorizer color/red color/red-bg))
 
-(def-colorize pass
-  color/green color/green-bg)
+(def pass (build-colorizer color/green color/green-bg))
 
-(def-colorize note
-  color/cyan color/cyan-bg)
+(def note (build-colorizer color/cyan color/cyan-bg))

--- a/src/midje/emission/colorize.clj
+++ b/src/midje/emission/colorize.clj
@@ -11,12 +11,12 @@
 (defmacro ^:private def-colorize
   [fn-name on reverse]
   `(defn ~fn-name
-     [s#]
-     ((case (config-choice :colorize)
-        :true ~on
-        :reverse ~reverse
-        str)
-      s#)))
+     [& s#]
+     (apply (case (config-choice :colorize)
+              :true ~on
+              :reverse ~reverse
+              str)
+            s#)))
 
 (def-colorize fail
   color/red color/red-bg)

--- a/src/midje/emission/colorize.clj
+++ b/src/midje/emission/colorize.clj
@@ -2,31 +2,19 @@
             Midje output be ergonomically colorful."}
   midje.emission.colorize
   (:require [colorize.core :as color]
-            [clojure.string :as str]
-            [midje.config :as config]
-            [midje.util.ecosystem :as ecosystem]))
+            [midje.config :as config]))
 
 ;; This indirection is required so that the tests of this
 ;; file can fake the prerequisite
 (def config-choice config/choice)
 
-(defn- config-choice-as-string []
-  (let [choice (config-choice :colorize)]
-    (if (keyword? choice)
-      (name choice)
-      (str choice))))
-
-(defn- colorize-string []
-  (str/upper-case (or (ecosystem/getenv "MIDJE_COLORIZE")
-                      (config-choice-as-string))))
-
 (defmacro ^:private def-colorize
   [fn-name on reverse]
   `(defn ~fn-name
      [s#]
-     ((case (colorize-string)
-        "TRUE" ~on
-        "REVERSE" ~reverse
+     ((case (config-choice :colorize)
+        :true ~on
+        :reverse ~reverse
         str)
       s#)))
 

--- a/test/midje/emission/t_colorize.clj
+++ b/test/midje/emission/t_colorize.clj
@@ -46,9 +46,14 @@
   color/note    "TRUE"            "\u001b[36mstring\u001b[0m"
   color/note    "reverse"         "\u001b[46mstring\u001b[0m")
 
-(fact "access environment vars only when namespace is loaded, not on each report line"
-  (prerequisite (getenv "MIDJE_COLORIZE") => anything :times 0)
+(fact "access environment vars on each report line"
+      (color/fail "a") => anything
+      (provided
+       (getenv "MIDJE_COLORIZE") => anything :times 1)
+      (color/note "b") => anything
+      (provided
+       (getenv "MIDJE_COLORIZE") => anything :times 1)
+      (color/fail "c") => anything
+      (provided
+       (getenv "MIDJE_COLORIZE") => anything :times 1))
 
-  (color/fail "a") => anything
-  (color/note "b") => anything
-  (color/fail "c") => anything)

--- a/test/midje/emission/t_colorize.clj
+++ b/test/midje/emission/t_colorize.clj
@@ -9,7 +9,6 @@
     (prerequisites (color/config-choice :colorize) => ?config-choice
                    (getenv "MIDJE_COLORIZE") => ?env-choice)
 
-    (color/init!)
     (?color-fn "string") => ?result)
 
   ?color-fn     ?env-choice   ?config-choice   ?result
@@ -36,7 +35,6 @@
 (tabular
   (fact "about the escape strings that apply to different choices"
     (prerequisite (getenv "MIDJE_COLORIZE") => ?env-value)
-    (color/init!)
     (?color-fn "string") => ?result)
 
   ?color-fn     ?env-value        ?result
@@ -47,10 +45,6 @@
   color/note    "FALSE"           "string"
   color/note    "TRUE"            "\u001b[36mstring\u001b[0m"
   color/note    "reverse"         "\u001b[46mstring\u001b[0m")
-
-;; Reset to user's default colorization.
-(color/init!)
-
 
 (fact "access environment vars only when namespace is loaded, not on each report line"
   (prerequisite (getenv "MIDJE_COLORIZE") => anything :times 0)

--- a/test/midje/emission/t_colorize.clj
+++ b/test/midje/emission/t_colorize.clj
@@ -1,59 +1,35 @@
 (ns midje.emission.t-colorize
   (:require [midje.sweet :refer :all]
-            [midje.util.ecosystem :refer [getenv on-windows?]]
-            [midje.emission.colorize :as color]
-            [midje.config :as config]))
+            [midje.util.ecosystem :as ecosystem]
+            [midje.emission.colorize :as color]))
 
 (tabular
-  (fact "wraps string in ascii color if the user so desires"
-    (prerequisites (color/config-choice :colorize) => ?config-choice
-                   (getenv "MIDJE_COLORIZE") => ?env-choice)
-
+ (fact "wraps string in ascii color if the user so desires"
+    (prerequisite (color/config-choice :colorize) => ?choice)
     (?color-fn "string") => ?result)
 
-  ?color-fn     ?env-choice   ?config-choice   ?result
+  ?color-fn   ?choice   ?result
+  color/fail  :false    "string"
+  color/fail  :true     "\u001b[31mstring\u001b[0m"
+  color/fail  :reverse  "\u001b[41mstring\u001b[0m"
 
-  ;; On windows, the config-choice defaults to false
-  color/fail    "FALSE"       false            "string"
-  color/fail    "TRUE"        false            "\u001b[31mstring\u001b[0m"
-  color/fail    "reverse"     false            "\u001b[41mstring\u001b[0m"
-  color/fail     nil          false            "string"
+  color/note  :false    "string"
+  color/note  :true     "\u001b[36mstring\u001b[0m"
+  color/note  :reverse  "\u001b[46mstring\u001b[0m"
 
-  ;; On Unixoids, the config-choice defaults to true
-  color/fail    "FALSE"       true             "string"
-  color/fail    "TRUE"        true             "\u001b[31mstring\u001b[0m"
-  color/fail    "reverse"     true             "\u001b[41mstring\u001b[0m"
-  color/fail     nil          true             "\u001b[31mstring\u001b[0m"
+  color/pass  :false   "string"
+  color/pass  :true    "\u001b[32mstring\u001b[0m"
+  color/pass  :reverse "\u001b[42mstring\u001b[0m")
 
-  ;; The user can set the config variable.
-  color/fail     nil          :reverse         "\u001b[41mstring\u001b[0m"
-
-  ;; The environment variable takes precedence
-  color/fail     "false"      :reverse         "string")
-
-
-(tabular
-  (fact "about the escape strings that apply to different choices"
-    (prerequisite (getenv "MIDJE_COLORIZE") => ?env-value)
-    (?color-fn "string") => ?result)
-
-  ?color-fn     ?env-value        ?result
-  color/fail    "FALSE"           "string"
-  color/fail    "TRUE"            "\u001b[31mstring\u001b[0m"
-  color/fail    "reverse"         "\u001b[41mstring\u001b[0m"
-
-  color/note    "FALSE"           "string"
-  color/note    "TRUE"            "\u001b[36mstring\u001b[0m"
-  color/note    "reverse"         "\u001b[46mstring\u001b[0m")
-
-(fact "access environment vars on each report line"
+(fact "access environment vars once, not on each report line"
       (color/fail "a") => anything
       (provided
-       (getenv "MIDJE_COLORIZE") => anything :times 1)
+       (ecosystem/getenv "MIDJE_COLORIZE") => anything :times 0)
+
       (color/note "b") => anything
       (provided
-       (getenv "MIDJE_COLORIZE") => anything :times 1)
+       (ecosystem/getenv "MIDJE_COLORIZE") => anything :times 0)
+
       (color/fail "c") => anything
       (provided
-       (getenv "MIDJE_COLORIZE") => anything :times 1))
-
+       (ecosystem/getenv "MIDJE_COLORIZE") => anything :times 0))

--- a/test/user/fus_config.clj
+++ b/test/user/fus_config.clj
@@ -98,34 +98,38 @@
           (meta fun) => (contains {:created-from [:has-this-meta-key]}))))))
 
 (facts "about setting :colorize"
-       (tabular
-        (fact "environment variable takes precedent over config"
-              (prerequisite (ecosystem/getenv "MIDJE_COLORIZE") => ?env-choice)
-              ;; Nest a binding of the config with a modification
-              (config/with-augmented-config {:colorize ?config-choice}
-                ;; Modify the root config and copy to the local binding
-                (set! config/*config* (config/load-env-vars))
-                ;; Make assertion about the local binding
-                (config/choice :colorize) => ?result))
+       (let [stashed-config config/*config*]
+         (try
+           (tabular
+            (fact "environment variable takes precedent over config"
+                  (prerequisite (ecosystem/getenv "MIDJE_COLORIZE") => ?env-choice)
+                  ;; Nest a binding of the config with a modification
+                  (config/with-augmented-config {:colorize ?config-choice}
+                    ;; Modify the root config and copy to the local binding
+                    (set! config/*config* (config/load-env-vars))
+                    ;; Make assertion about the local binding
+                    (config/choice :colorize) => ?result))
 
-        ?env-choice ?config-choice ?result
-        "TRUE"      :true          :true
-        "TRUE"      :reverse       :true
-        "TRUE"      :false         :true
+            ?env-choice ?config-choice ?result
+            "TRUE"      :true          :true
+            "TRUE"      :reverse       :true
+            "TRUE"      :false         :true
 
-        "FALSE"     :true          :false
-        "FALSE"     :false         :false
-        "FALSE"     :reverse       :false
+            "FALSE"     :true          :false
+            "FALSE"     :false         :false
+            "FALSE"     :reverse       :false
 
-        "REVERSE"   :true          :reverse
-        "reverse"   :false         :reverse
-        "REVERSE"   :reverse       :reverse
+            "REVERSE"   :true          :reverse
+            "reverse"   :false         :reverse
+            "REVERSE"   :reverse       :reverse
 
-        nil         :true          :true
-        nil         :false         :false
-        nil         :reverse       :reverse
+            nil         :true          :true
+            nil         :false         :false
+            nil         :reverse       :reverse
 
-        ;; Testing the normalization
-        nil         "TRUE"         :true
-        nil         true           :true
-        nil         :true          :true))
+            ;; Testing the normalization
+            nil         "TRUE"         :true
+            nil         true           :true
+            nil         :true          :true)
+           (finally
+             (config/merge-permanently! stashed-config)))))


### PR DESCRIPTION
Fixes #458.

While the internal representation of the `:colorize` config key has changed from a string to a keyword, this should be fully backwards compatible with whatever users have in `MIDJE_COLORIZE` or `.midje.clj`.