### PR TITLE
slove dead loop problem when in repl

### DIFF
--- a/src/midje/repl.clj
+++ b/src/midje/repl.clj
@@ -505,6 +505,7 @@
   The default is to check twice each second.
   "
   [& args]
+  (scheduling/stop :autotest)
   (letfn [(start-periodic-check []
             (scheduling/schedule :autotest
                                  (project-state/mkfn:react-to-changes (autotest-options))


### PR DESCRIPTION
#446
(autotest :filter :one ) change to (autotest :filter :two ) will into dead loop