### PR TITLE
Update doc to mention proper meta

### DIFF
--- a/test/as_documentation/about_privates/how_to_refer_to_privates_in_facts.clj
+++ b/test/as_documentation/about_privates/how_to_refer_to_privates_in_facts.clj
@@ -19,7 +19,7 @@
       (#'da/da-called 1) => 8988)))
 
 
-;; 2. Alternately, you can tag private vars with ^{:private true} metadata, and then
+;; 2. Alternately, you can tag private vars with ^{:testable true} metadata, and then
 ;;    "expose" them with `expose-testables`.
 
 (require '[as-documentation.about-privates.privates-for-expose-testables])


### PR DESCRIPTION
To use `expose-testables` functions must have the `:testable` meta and not `:private`.