### PR TITLE
Add clj-kondo hooks and base config to classpath

### DIFF
--- a/test-resources/clj-kondo.exports/marick/midje/config.edn
+++ b/test-resources/clj-kondo.exports/marick/midje/config.edn
@@ -1,0 +1,11 @@
+{:hooks {:analyze-call {midje.sweet/tabular marick.midje/tabular}}
+ :linters {:unresolved-symbol {:exclude [=>
+                                         =not=>
+                                         =deny=>
+                                         =expands-to=>
+                                         =future=>
+                                         =contains=>
+                                         =streams=>
+                                         =throws=>
+                                         =test=>
+                                         =throw-parse-exception=>]}}}

--- a/test-resources/clj-kondo.exports/marick/midje/marick/midje.clj
+++ b/test-resources/clj-kondo.exports/marick/midje/marick/midje.clj
@@ -8,16 +8,24 @@
          (string/starts-with? (str sexpr) "?"))))
 
 (defn ^:private let-with-table-variables [body bindings]
-  (let [new-bindings (vec (reduce (fn [acc i]
-                                    (concat acc [i nil])) [] bindings))]
+  (let [new-bindings (vec (reduce (fn [acc i] (concat acc [i (hooks/token-node 'identity)]))
+                                  [] bindings))]
     (hooks/list-node
      [(hooks/token-node 'let)
       (hooks/vector-node new-bindings)
       body])))
 
+(defn ^:private do-form [forms]
+  (hooks/list-node
+    (concat [(hooks/token-node 'do)]
+            forms)))
+
 (defn tabular [{:keys [node]}]
-  (let [[facts & bindings] (rest (:children node))
-        new-node (->> bindings
-                      (filter table-variable?)
-                      (let-with-table-variables facts))]
-    {:node new-node}))
+  (let [[facts vec-bindings & bindings] (rest (:children node))]
+    (if (hooks/vector-node? vec-bindings)
+      {:node (let-with-table-variables
+               (do-form (cons facts bindings))
+               (map hooks/token-node (hooks/sexpr vec-bindings)))}
+      {:node (->> (cons vec-bindings bindings)
+                  (filter table-variable?)
+                  (let-with-table-variables facts))})))

--- a/test-resources/clj-kondo.exports/marick/midje/marick/midje.clj
+++ b/test-resources/clj-kondo.exports/marick/midje/marick/midje.clj
@@ -1,0 +1,23 @@
+(ns marick.midje
+  (:require [clj-kondo.hooks-api :as hooks]
+            [clojure.string :as string]))
+
+(defn table-variable? [node]
+  (let [sexpr (hooks/sexpr node)]
+    (and (symbol? sexpr)
+         (string/starts-with? (str sexpr) "?"))))
+
+(defn ^:private let-with-table-variables [body bindings]
+  (let [new-bindings (vec (reduce (fn [acc i]
+                                    (concat acc [i nil])) [] bindings))]
+    (hooks/list-node
+     [(hooks/token-node 'let)
+      (hooks/vector-node new-bindings)
+      body])))
+
+(defn tabular [{:keys [node]}]
+  (let [[facts & bindings] (rest (:children node))
+        new-node (->> bindings
+                      (filter table-variable?)
+                      (let-with-table-variables facts))]
+    {:node new-node}))


### PR DESCRIPTION
It's possible to have [clj-kondo](https://github.com/clj-kondo/clj-kondo) configuration on classpath of a lib, with that, any user using clj-kondo could benefit of the configuration and just need to add `{:config-paths "marick/midje"}` to their clj-kondo config file.

More information about this clj-kondo config [here](https://github.com/clj-kondo/clj-kondo/blob/master/doc/config.md#exporting-and-importing-configuration)
Another lib example which did that [here](https://github.com/nubank/state-flow/tree/master/resources/clj-kondo.exports/nubank/state-flow)

For this PR, I'm adding support for `tabular` making clj-kondo understands its table variables, also excluding from the linter the arrow symbols.