### PR TITLE
[clj-kondo] Add support for midje checkers

### DIFF
--- a/test-resources/clj-kondo.exports/marick/midje/config.edn
+++ b/test-resources/clj-kondo.exports/marick/midje/config.edn
@@ -1,4 +1,5 @@
 {:hooks {:analyze-call {midje.sweet/tabular marick.midje/tabular}}
+ :lint-as {midje.checking.checkers.defining/defchecker clojure.core/defn
  :linters {:unresolved-symbol {:exclude [(midje.sweet/fact
                                           [throws
                                            contains


### PR DESCRIPTION
This should make clj-kondo understand the midje checkers only when inside fact/facts and not globally, also I added missing checkers besides the arrows.