### PR TITLE
Bump some libs + remove slingshot dep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 This project adheres to [Semantic Versioning](http://semver.org/).
 See [here](http://keepachangelog.com/) for the change log format.
 
+## [1.10.6] - 2022-03-28
+- bump libraries
+
 ## [1.10.5] - 2021-10-27
 - Add midje.sweet/tabular `clj-kondo` config
 

--- a/project.clj
+++ b/project.clj
@@ -1,26 +1,25 @@
-(defproject midje "1.10.5"
+(defproject midje "1.10.6"
   :description "A TDD library for Clojure that supports top-down ('mockish') TDD, encourages readable tests, provides a smooth migration path from clojure.test, balances abstraction and concreteness, and strives for graciousness."
   :url "https://github.com/marick/Midje"
   :pedantic? :warn
   :dependencies [[org.clojure/clojure "1.9.0"]
-                 [marick/suchwow "6.0.2" :exclusions [org.clojure/clojure org.clojure/clojurescript]]
-                 [org.clojure/math.combinatorics "0.1.5"]
-                 [io.aviso/pretty "0.1.37" :exclusions [org.clojure/clojure]]
+                 [marick/suchwow "6.0.3" :exclusions [org.clojure/clojure org.clojure/clojurescript]]
+                 [org.clojure/math.combinatorics "0.1.6"]
+                 [io.aviso/pretty "1.1.1" :exclusions [org.clojure/clojure]]
                  [org.clojure/core.unify "0.5.7" :exclusions [org.clojure/clojure]]
-                 [org.clojure/test.check "0.10.0-alpha3"]
+                 [org.clojure/test.check "1.1.1"]
                  [clj-time "0.15.1" :exclusions [org.clojure/clojure]]
                  [colorize "0.1.1" :exclusions [org.clojure/clojure]]
                  [org.clojure/tools.macro "0.1.5"]
-                 [org.tcrawley/dynapath "1.0.0"]
-                 [org.clojure/tools.namespace "0.3.0"]
+                 [org.tcrawley/dynapath "1.1.0"]
+                 [org.clojure/tools.namespace "1.2.0"]
                  [flare "0.2.9" :exclusions [org.clojure/clojure]]
-                 [slingshot "0.12.2"]
-                 [mvxcvi/puget "1.1.2" :exclusions [org.clojure/clojure]]]
-  :profiles {:dev {:dependencies [[prismatic/plumbing "0.5.5"]]
+                 [mvxcvi/puget "1.3.2" :exclusions [org.clojure/clojure]]]
+  :profiles {:dev {:dependencies [[prismatic/plumbing "0.6.0"]]
                    :plugins [[lein-midje "3.2.1"]
                              [lein-ancient "0.6.15" :exclusions [com.fasterxml.jackson.core/jackson-databind
                                                                  com.fasterxml.jackson.core/jackson-core]]]}
-             :test-libs {:dependencies [[prismatic/plumbing "0.5.5"]]}
+             :test-libs {:dependencies [[prismatic/plumbing "0.6.0"]]}
              :1.7 [:test-libs {:dependencies [[org.clojure/clojure "1.7.0"]]}]
              :1.8 [:test-libs {:dependencies [[org.clojure/clojure "1.8.0"]]}]
              :1.9 [:test-libs {:dependencies [[org.clojure/clojure "1.9.0"]]}]


### PR DESCRIPTION
so people don't need to do stuff like https://github.com/nubank/matcher-combinators/pull/169/files#diff-274071745a4e2a04b647d79d500537e6dc13eee54f44d0426140026293701d1bR20-R23

I think slingshot was breaking with newer versions of clojure. I didn't bump clojure off of `1.9` though because tests related to  stacktraces would need to be updated and I don't want to deal with that right now