### PR TITLE
Allow setting midje config via java system properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 This project adheres to [Semantic Versioning](http://semver.org/).
 See [here](http://keepachangelog.com/) for the change log format.
 
+## [1.10.6] - 2022-10-17
+- Allow setting midje config via java system properties (#483)
+
+  For example: `(System/setProperty "midje.check-after-creation" "false")` can now be done instead of `(change-defaults :check-after-creation false)` in the `.midje.clj` config file
+
 ## [1.10.5] - 2021-10-27
 - Add midje.sweet/tabular `clj-kondo` config
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject midje "1.10.5"
+(defproject midje "1.10.6"
   :description "A TDD library for Clojure that supports top-down ('mockish') TDD, encourages readable tests, provides a smooth migration path from clojure.test, balances abstraction and concreteness, and strives for graciousness."
   :url "https://github.com/marick/Midje"
   :pedantic? :warn

--- a/src/midje/config.clj
+++ b/src/midje/config.clj
@@ -1,6 +1,7 @@
-(ns ^{:doc "Customizable configuration"}
-  midje.config
-  (:require [clojure.string :as str]
+(ns midje.config
+  "Customizable configuration"
+  (:require [clojure.edn :as edn]
+            [clojure.string :as str]
             [midje.emission.levels :as levels]
             [midje.util.ecosystem :as ecosystem]
             [midje.util.exceptions :refer [user-error]]
@@ -78,8 +79,14 @@
      ~@body))
 
 (defn choice
-  "Returns the configuration value of `key`"
-  [key] (*config* key))
+  "Returns the configuration value of `key`
+
+  If a java system property `midje.the-key` is set, uses that value instead of
+  whatever is in the config at `:the-key`"
+  [key]
+  (if-let [property-override (System/getProperty (str "midje." (name key)))]
+    (edn/read-string property-override)
+    (get *config* key)))
 
 (defn merge-permanently!
   "Merges the given map into the root configuration.

--- a/src/midje/doc.clj
+++ b/src/midje/doc.clj
@@ -277,6 +277,9 @@
       (midje.config/with-augmented-config {:print-level :print-no-summary}
          <forms>...)
 
+  or by setting java system properties:
+      (System/setProperty \"midje.print-level\" \":print-namespaces\")
+
   ------ Configuration keywords
   :print-level                  ; Verbosity of printing.
                                 ; See `(doc midje-print-levels)`.

--- a/test/behaviors/t_canary.clj
+++ b/test/behaviors/t_canary.clj
@@ -9,15 +9,21 @@
 
 
 (unfinished favorite-animal)
-(defn favorite-animal-name [] (name (favorite-animal)))
+
+;; create custom name' to get around the fact that midje uses
+;; `clojure.core/name` and so examples that redef `name` via `provided` cause
+;; issues
+(def name' name)
+
+(defn favorite-animal-name [] (name' (favorite-animal)))
 (defn favorite-animal-empty [] )
 (defn favorite-animal-only-animal [] (favorite-animal))
-(defn favorite-animal-only-name [] (name "fred"))
+(defn favorite-animal-only-name [] (name' "fred"))
 
 (fact
      (favorite-animal-name) => "betsy"
      (provided
-       (name (favorite-animal)) => "betsy"))
+       (name' (favorite-animal)) => "betsy"))
 
 
 


### PR DESCRIPTION
addresses https://github.com/marick/Midje/issues/482

allows for doing things like:
```
(System/setProperty "midje.check-after-creation" "false")

;; run Eastwood analysis...

(System/setProperty "midje.check-after-creation" "true")
```
this is important because things like Eastwood analysis will load a bunch of namespaces but we want to avoid executing midje facts tests because that slows things down / has side-effects.

Given a config key like `:my-key`, the way to override it via system properties would be to set `"midje.my-key"`