### PR TITLE
Update error handling to deal with Clojure 1.10 exception improvements

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -2,8 +2,7 @@
   :description "A TDD library for Clojure that supports top-down ('mockish') TDD, encourages readable tests, provides a smooth migration path from clojure.test, balances abstraction and concreteness, and strives for graciousness."
   :url "https://github.com/marick/Midje"
   :pedantic? :warn
-  :dependencies [;; Note that in order to bump past Clojure 1.9.0 a test suite rehaul is needed given Clojure's improvements to macroexpansion errors
-                 [org.clojure/clojure "1.9.0"]
+  :dependencies [[org.clojure/clojure "1.9.0"]
                  [marick/suchwow "6.0.3" :exclusions [org.clojure/clojure org.clojure/clojurescript]]
                  [org.clojure/math.combinatorics "0.1.6"]
                  [io.aviso/pretty "1.3" :exclusions [org.clojure/clojure]]
@@ -24,6 +23,9 @@
              :1.7 [:test-libs {:dependencies [[org.clojure/clojure "1.7.0"]]}]
              :1.8 [:test-libs {:dependencies [[org.clojure/clojure "1.8.0"]]}]
              :1.9 [:test-libs {:dependencies [[org.clojure/clojure "1.9.0"]]}]
+             :1.10 [:test-libs {:dependencies [[org.clojure/clojure "1.10.3"]]}]
+             :1.11 [:test-libs {:dependencies [[org.clojure/clojure "1.11.1"]]}]
+             :1.12 [:test-libs {:dependencies [[org.clojure/clojure "1.12.0-alpha5"]]}]
              ;; The following profile can be used to check that `lein with-profile`
              ;; profiles are obeyed. Note that profile `:test-paths` *add on* to the
              ;; defaults.

--- a/src/midje/checking/checkers/simple.clj
+++ b/src/midje/checking/checkers/simple.clj
@@ -58,10 +58,13 @@
 ;; Concerning Throwables
 
 (letfn [(throwable-as-desired? [throwable desideratum]
-           (branch-on desideratum
-                   fn?                        (desideratum throwable)
-                   (some-fn string? regex?)   (extended-= (.getMessage ^Throwable throwable) desideratum)
-                   class?                     (instance? desideratum throwable)))]
+           ;; Handle CompilerExceptions from 1.10+
+           (if (contains? (ex-data throwable) :clojure.error/phase)
+             (recur (.getCause throwable) desideratum)
+             (branch-on desideratum
+               fn?                        (desideratum throwable)
+               (some-fn string? regex?)   (extended-= (.getMessage ^Throwable throwable) desideratum)
+               class?                     (instance? desideratum throwable))))]
 
   (defchecker throws
     "Checks for a thrown Throwable.

--- a/src/midje/parsing/util/error_handling.clj
+++ b/src/midje/parsing/util/error_handling.clj
@@ -37,15 +37,16 @@
       (binding [*wrap-count* (inc *wrap-count*)]
         (try
          (parser)
-         (catch clojure.lang.ExceptionInfo ex
-           (if (= ::bail-out-of-parsing (-> ex ex-data :type))
-             false
-             (do
-               (report-exception ex)
-               false)))
          (catch Exception ex
-           (report-exception ex)
-           false))))))
+           (let [;; Handle CompilerExceptions from 1.10+
+                 ex (if (contains? (ex-data ex) :clojure.error/phase)
+                      (.getCause ex)
+                      ex)]
+             (if (= ::bail-out-of-parsing (-> ex ex-data :type))
+               false
+               (do
+                 (report-exception ex)
+                 false)))))))))
 
 
 

--- a/test/implementation/parsing/util/fim_exception_line_numbers.clj
+++ b/test/implementation/parsing/util/fim_exception_line_numbers.clj
@@ -1,4 +1,4 @@
-(ns implementation.parsing.util.fim_exception_line_numbers
+(ns implementation.parsing.util.fim-exception-line-numbers
   (:require [midje
              [sweet :refer :all]
              [test-util :refer :all]]))

--- a/test/midje/parsing/2_to_lexical_maps/t_fakes.clj
+++ b/test/midje/parsing/2_to_lexical_maps/t_fakes.clj
@@ -24,7 +24,7 @@
 
 (silent-fact "results in stack overflow"
   (my-fn 'url) => 'some-result
-  (provided (noop (str 'url)) => 'some-result))
+  (provided (noop (my-fn 'url)) => 'some-result))
 (note-that (fact-captured-throwable-with-message #"You seem to have created a prerequisite*"))
 
 (fact "note that you can get around it by not mocking `str`"


### PR DESCRIPTION
Includes the `str` -> `my-fn` change I mentioned in #488, which still fails but fails more intelligently.

Without CI checking stuff, it's hard to say this is good to go. Might I suggestion Github actions?